### PR TITLE
Compiler Flag Cleanup, main branch (2023.10.09.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -56,10 +56,10 @@ jobs:
         -DCMAKE_CXX_COMPILER=$(which ${{ matrix.COMPILER.CXX }})
         -DCMAKE_BUILD_TYPE=${{ matrix.BUILD }}
         -DCOVFIE_REQUIRE_CXX20=${{ matrix.CXX_STANDARD == 20 && 'On' || 'Off' }}
+        -DCOVFIE_FAIL_ON_WARNINGS=TRUE
         -DCOVFIE_BUILD_TESTS=On
         -DCOVFIE_BUILD_EXAMPLES=On
         -DCOVFIE_BUILD_BENCHMARKS=On
-        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
         -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }}
         -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/.prefixes/gtest/"
         -S $GITHUB_WORKSPACE
@@ -117,12 +117,12 @@ jobs:
         -DCMAKE_BUILD_TYPE=${{ matrix.BUILD }}
         -DCMAKE_CUDA_ARCHITECTURES=52
         -DCMAKE_CUDA_HOST_COMPILER=$(which g++-10)
+        -DCOVFIE_FAIL_ON_WARNINGS=TRUE
         -DCOVFIE_BUILD_TESTS=On
         -DCOVFIE_BUILD_EXAMPLES=On
         -DCOVFIE_BUILD_BENCHMARKS=On
         -DCOVFIE_PLATFORM_CUDA=On
         -DCOVFIE_PLATFORM_CPU=On
-        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
         -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }}
         -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/.prefixes/gtest/"
         -S $GITHUB_WORKSPACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022 CERN
+# Copyright (c) 2022-2023 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -49,6 +49,14 @@ option(
     COVFIE_QUIET
     "Disable warnings about missing C++ features. Enabling this is strongly discouraged."
 )
+
+option(
+    COVFIE_FAIL_ON_WARNINGS
+    "Treat compiler warnings as errors."
+)
+
+# Make the CMake modules in the cmake/ directory visible to the project.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # The core library should always be built.
 add_subdirectory(lib)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022 CERN
+# Copyright (c) 2022-2023 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -15,6 +15,9 @@ find_package(
     1.71.0
     REQUIRED
 )
+
+# Set up the C++ compiler flags for the benchmarks.
+include(covfie-compiler-options-cpp)
 
 # Common benchmarking components must be build.
 add_subdirectory(common)

--- a/benchmarks/cuda/CMakeLists.txt
+++ b/benchmarks/cuda/CMakeLists.txt
@@ -1,12 +1,15 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022 CERN
+# Copyright (c) 2022-2023 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 
 enable_language(CUDA)
+
+# Set up the CUDA compiler flags for the benchmarks.
+include(covfie-compiler-options-cuda)
 
 # Create the benchmark executable from the individual files.
 add_executable(

--- a/cmake/covfie-compiler-options-cpp.cmake
+++ b/cmake/covfie-compiler-options-cpp.cmake
@@ -1,0 +1,43 @@
+# This file is part of covfie, a part of the ACTS project
+#
+# Copyright (c) 2023 CERN
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+# Include the helper function(s).
+include( covfie-functions )
+
+# Turn on a number of warnings for the "known compilers".
+if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
+    ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" ) )
+
+   # Basic flags for all build modes.
+   covfie_add_flag( CMAKE_CXX_FLAGS "-Wall" )
+   covfie_add_flag( CMAKE_CXX_FLAGS "-Wextra" )
+   covfie_add_flag( CMAKE_CXX_FLAGS "-Wshadow" )
+   covfie_add_flag( CMAKE_CXX_FLAGS "-Wunused-local-typedefs" )
+   covfie_add_flag( CMAKE_CXX_FLAGS "-pedantic" )
+
+   # Fail on warnings, if asked for that behaviour.
+   if( COVFIE_FAIL_ON_WARNINGS )
+      covfie_add_flag( CMAKE_CXX_FLAGS "-Werror" )
+   endif()
+
+elseif( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
+
+   # Basic flags for all build modes.
+   string( REGEX REPLACE "/W[0-9]" "" CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS}" )
+   covfie_add_flag( CMAKE_CXX_FLAGS "/W4" )
+
+   # Fail on warnings, if asked for that behaviour.
+   if( COVFIE_FAIL_ON_WARNINGS )
+      covfie_add_flag( CMAKE_CXX_FLAGS "/WX" )
+   endif()
+
+   # Turn on the correct setting for the __cplusplus macro with MSVC.
+   covfie_add_flag( CMAKE_CXX_FLAGS "/Zc:__cplusplus" )
+
+endif()

--- a/cmake/covfie-compiler-options-cuda.cmake
+++ b/cmake/covfie-compiler-options-cuda.cmake
@@ -1,0 +1,44 @@
+# This file is part of covfie, a part of the ACTS project
+#
+# Copyright (c) 2023 CERN
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+# FindCUDAToolkit needs at least CMake 3.17.
+cmake_minimum_required( VERSION 3.17 )
+
+# Include the helper function(s).
+include( covfie-functions )
+
+# Figure out the properties of CUDA being used.
+find_package( CUDAToolkit REQUIRED )
+
+# Set the architecture to build code for.
+set( CMAKE_CUDA_ARCHITECTURES "52" CACHE STRING
+   "CUDA architectures to build device code for" )
+
+# Turn on the correct setting for the __cplusplus macro with MSVC.
+if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
+   covfie_add_flag( CMAKE_CUDA_FLAGS "-Xcompiler /Zc:__cplusplus" )
+endif()
+
+if( "${CMAKE_CUDA_COMPILER_ID}" MATCHES "NVIDIA" )
+   # Make CUDA generate debug symbols for the device code as well in a debug
+   # build.
+   covfie_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G" )
+   # Allow to use functions in device code that are constexpr, even if they are
+   # not marked with __device__.
+   covfie_add_flag( CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr" )
+endif()
+
+# Fail on warnings, if asked for that behaviour.
+if( COVFIE_FAIL_ON_WARNINGS )
+   if( ( "${CUDAToolkit_VERSION}" VERSION_GREATER_EQUAL "10.2" ) AND
+       ( "${CMAKE_CUDA_COMPILER_ID}" MATCHES "NVIDIA" ) )
+      covfie_add_flag( CMAKE_CUDA_FLAGS "-Werror all-warnings" )
+   elseif( "${CMAKE_CUDA_COMPILER_ID}" MATCHES "Clang" )
+      covfie_add_flag( CMAKE_CUDA_FLAGS "-Werror" )
+   endif()
+endif()

--- a/cmake/covfie-functions.cmake
+++ b/cmake/covfie-functions.cmake
@@ -1,0 +1,29 @@
+# This file is part of covfie, a part of the ACTS project
+#
+# Copyright (c) 2023 CERN
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+# Helper function for adding individual flags to "flag variables".
+#
+# Usage: covfie_add_flag( CMAKE_CXX_FLAGS "-Wall" )
+#
+function( covfie_add_flag name value )
+
+   # Escape special characters in the value:
+   set( matchedValue "${value}" )
+   foreach( c "*" "." "^" "$" "+" "?" )
+      string( REPLACE "${c}" "\\${c}" matchedValue "${matchedValue}" )
+   endforeach()
+
+   # Check if the variable already has this value in it:
+   if( "${${name}}" MATCHES "${matchedValue}" )
+      return()
+   endif()
+
+   # If not, then let's add it now:
+   set( ${name} "${${name}} ${value}" PARENT_SCOPE )
+
+endfunction( covfie_add_flag )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,10 +1,13 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022 CERN
+# Copyright (c) 2022-2023 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
+
+# Set up the C++ compiler flags for the examples.
+include(covfie-compiler-options-cpp)
 
 # The common tools should be available for examples on all platforms.
 add_subdirectory(common)

--- a/examples/cuda/CMakeLists.txt
+++ b/examples/cuda/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022 CERN
+# Copyright (c) 2022-2023 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -9,6 +9,9 @@
 # First, we need to make sure that we have a CUDA compiler, and that all the
 # necessary tooling is set up.
 enable_language(CUDA)
+
+# Set up the CUDA compiler flags for the examples.
+include(covfie-compiler-options-cuda)
 
 # Add the 3D field slice rendering tool based on CUDA.
 add_executable(

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022 CERN
+# Copyright (c) 2022-2023 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -14,9 +14,6 @@ target_include_directories(
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-
-# Remove this line!
-target_compile_options(core INTERFACE "-Wall" "-Wextra")
 
 target_compile_features(core INTERFACE cxx_std_17)
 

--- a/lib/cpu/CMakeLists.txt
+++ b/lib/cpu/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022 CERN
+# Copyright (c) 2022-2023 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -14,9 +14,6 @@ target_include_directories(
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-
-# Remove this line!
-target_compile_options(cpu INTERFACE "-Wall" "-Wextra")
 
 target_compile_features(cpu INTERFACE cxx_std_17)
 

--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022 CERN
+# Copyright (c) 2022-2023 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -15,14 +15,6 @@ target_include_directories(
     INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
-
-# Remove this line!
-target_compile_options(
-    cuda
-    INTERFACE
-    -Wall -Wextra
-    $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>
 )
 
 target_compile_features(cuda INTERFACE cxx_std_17)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022 CERN
+# Copyright (c) 2022-2023 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -8,6 +8,9 @@
 
 # All the tests here will require Google Test, so we will go ahead and find it.
 find_package(GTest CONFIG REQUIRED)
+
+# Set up the C++ compiler flags for the tests.
+include(covfie-compiler-options-cpp)
 
 # The testing utils are always built.
 add_subdirectory(utils)

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022 CERN
+# Copyright (c) 2022-2023 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -8,6 +8,9 @@
 
 # Enable the CUDA language!
 enable_language(CUDA)
+
+# Set up the CUDA compiler flags for the tests.
+include(covfie-compiler-options-cuda)
 
 # Create the test executable from the individual test groups.
 add_executable(


### PR DESCRIPTION
Removed the hardcoded compiler flags from the `covfie::core` and `covfie::cuda` libraries, and replaced them with the same sort of "directory scope" flag settings that we use in the other R&D projects as well.

This is needed as input for making Detray functional on Windows. :wink: But in general, this should be a healthy update for the project's configuration.