### PR TITLE
Windows tests

### DIFF
--- a/cmake/covfie-functions.cmake
+++ b/cmake/covfie-functions.cmake
@@ -6,6 +6,53 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 
+# Helper function testing the covfie public headers.
+#
+# It can be used to test that public headers would include everything
+# that they need to work, and that the CMake library targets would take
+# care of declaring all of their dependencies correctly for the public
+# headers to work.
+#
+# Usage: covfie_test_public_headers( covfie_core
+#                                    include/header1.hpp ... )
+#
+function( covfie_test_public_headers library )
+
+   # If testing is not turned on, don't do anything.
+   if( NOT COVFIE_BUILD_TESTS )
+      return()
+   endif()
+
+   # All arguments are treated as header file names.
+   foreach( _headerName ${ARGN} )
+
+      # Make the header filename into a "string".
+      string( REPLACE "/" "_" _headerNormName "${_headerName}" )
+      string( REPLACE "." "_" _headerNormName "${_headerNormName}" )
+
+      # Write a small source file that would test that the public
+      # header can be used as-is.
+      set( _testFileName
+         "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/test_${library}_${_headerNormName}.cpp" )
+      if( NOT EXISTS "${_testFileName}" )
+         file( WRITE "${_testFileName}"
+            "#include \"${_headerName}\"\n"
+            "int main() { return 0; }" )
+      endif()
+
+      # Set up an executable that would build it. But hide it, don't put it
+      # into ${CMAKE_BINARY_DIR}/bin.
+      add_executable( "test_${library}_${_headerNormName}" "${_testFileName}" )
+      target_link_libraries( "test_${library}_${_headerNormName}"
+         PRIVATE ${library} )
+      set_target_properties( "test_${library}_${_headerNormName}" PROPERTIES
+         RUNTIME_OUTPUT_DIRECTORY
+         "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}" )
+
+   endforeach()
+
+endfunction( covfie_test_public_headers )
+
 # Helper function for adding individual flags to "flag variables".
 #
 # Usage: covfie_add_flag( CMAKE_CXX_FLAGS "-Wall" )

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -47,3 +47,9 @@ install(
 # Hack for people using the disgusting mal-practice of pullling in external
 # projects via "add_subdirectory"...
 add_library(covfie::core ALIAS core)
+
+# Test the public headers of covfie::core.
+#include(covfie-functions)
+#file(GLOB_RECURSE public_headers RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+#     "${CMAKE_CURRENT_SOURCE_DIR}/covfie/*.hpp")
+#covfie_test_public_headers(core "${public_headers}")

--- a/lib/core/covfie/core/algebra/vector.hpp
+++ b/lib/core/covfie/core/algebra/vector.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -42,8 +42,9 @@ struct vector : public matrix<N, 1, T, I> {
     template <
         typename... Args,
         std::enable_if_t<
-            (std::is_scalar_v<Args> && ...) &&
-                (std::is_convertible_v<Args, T> && ...) && sizeof...(Args) == N,
+            std::conjunction_v<std::is_scalar<Args>...> &&
+                std::conjunction_v<std::is_convertible<Args, T>...> &&
+                sizeof...(Args) == N,
             bool> = true>
     COVFIE_DEVICE vector(Args... args)
         : vector(std::array<T, N>{std::forward<Args>(args)...})

--- a/lib/core/covfie/core/backend/primitive/array.hpp
+++ b/lib/core/covfie/core/backend/primitive/array.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -130,10 +130,15 @@ struct array {
 
             for (std::size_t i = 0; i < size; ++i) {
                 for (std::size_t j = 0; j < _output_vector_t::size; ++j) {
+                    using scalar_t = typename _output_vector_t::type;
                     if (float_width == 4) {
-                        ptr[i][j] = utility::read_binary<float>(fs);
+                        ptr[i][j] =
+                            static_cast<scalar_t>(utility::read_binary<float>(fs
+                            ));
                     } else if (float_width == 8) {
-                        ptr[i][j] = utility::read_binary<double>(fs);
+                        ptr[i][j] = static_cast<scalar_t>(
+                            utility::read_binary<double>(fs)
+                        );
                     } else {
                         throw std::logic_error("Float width is unexpected.");
                     }

--- a/lib/core/covfie/core/backend/transformer/backup.hpp
+++ b/lib/core/covfie/core/backend/transformer/backup.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -16,6 +16,7 @@
 
 #include <covfie/core/concepts.hpp>
 #include <covfie/core/qualifiers.hpp>
+#include <covfie/core/utility/binary_io.hpp>
 #include <covfie/core/utility/nd_size.hpp>
 #include <covfie/core/vector.hpp>
 

--- a/lib/core/covfie/core/backend/transformer/strided.hpp
+++ b/lib/core/covfie/core/backend/transformer/strided.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -154,7 +154,7 @@ struct strided {
             , m_storage(std::accumulate(
                   std::begin(m_sizes),
                   std::end(m_sizes),
-                  1,
+                  static_cast<std::size_t>(1),
                   std::multiplies<std::size_t>()
               ))
         {
@@ -253,7 +253,10 @@ struct strided {
                      l < contravariant_input_t::dimensions;
                      ++l)
                 {
-                    tmp *= m_sizes[l];
+                    tmp *=
+                        static_cast<typename contravariant_input_t::scalar_t>(
+                            m_sizes[l]
+                        );
                 }
 
                 idx += tmp;

--- a/lib/core/covfie/core/definitions.hpp
+++ b/lib/core/covfie/core/definitions.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -18,9 +18,15 @@ is configured to reject such set-ups. Consider upgrating to C++20 or \
 disabling the COVFIE_REQUIRE_CXX20 flag."
 #else
 #if !defined(COVFIE_QUIET)
+#ifdef _WIN32
+#pragma message("C++20 concepts are not supported by the current compiler.\n"  \
+                "covfie will compile as normal, but compile-time\n"            \
+                "guarantees will be weaker. Consider upgrading to C++20.")
+#else
 #pragma message "C++20 concepts are not supported by the current compiler. \
 covfie will compile as normal, but compile-time guarantees will be \
 weaker. Consider upgrading to C++20."
+#endif // _WIN32
 #endif
 #define CONSTRAINT(x) typename
 #endif

--- a/lib/core/covfie/core/field.hpp
+++ b/lib/core/covfie/core/field.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -31,7 +31,6 @@ public:
     static constexpr uint32_t IO_MAGIC_HEADER = 0xAB000000;
 
     field() = default;
-    field(field &) = default;
     field(const field &) = default;
     field(field &&) = default;
 

--- a/lib/core/covfie/core/field_view.hpp
+++ b/lib/core/covfie/core/field_view.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -45,10 +45,9 @@ public:
         typename... Args,
         typename Q = coordinate_t,
         std::enable_if_t<
-            (std::is_convertible_v<
-                 Args,
-                 typename backend_t::contravariant_input_t::scalar_t> &&
-             ...),
+            std::conjunction_v<std::is_convertible<
+                Args,
+                typename backend_t::contravariant_input_t::scalar_t>...>,
             bool> = true,
         std::enable_if_t<
             sizeof...(Args) == backend_t::contravariant_input_t::dimensions,
@@ -56,7 +55,9 @@ public:
         std::enable_if_t<!std::is_scalar_v<Q>, bool> = true>
     COVFIE_DEVICE output_t at(Args... c) const
     {
-        return m_storage.at(coordinate_t{c...});
+        return m_storage.at(coordinate_t{
+            static_cast<typename backend_t::contravariant_input_t::scalar_t>(c
+            )...});
     }
 
     template <

--- a/lib/core/covfie/core/vector.hpp
+++ b/lib/core/covfie/core/vector.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -65,10 +65,10 @@ using int2 = vector_d<int, 2>;
 using int3 = vector_d<int, 3>;
 using int4 = vector_d<int, 4>;
 
-using uint1 = vector_d<uint, 1>;
-using uint2 = vector_d<uint, 2>;
-using uint3 = vector_d<uint, 3>;
-using uint4 = vector_d<uint, 4>;
+using uint1 = vector_d<unsigned int, 1>;
+using uint2 = vector_d<unsigned int, 2>;
+using uint3 = vector_d<unsigned int, 3>;
+using uint4 = vector_d<unsigned int, 4>;
 
 using long1 = vector_d<long, 1>;
 using long2 = vector_d<long, 2>;

--- a/lib/cpu/CMakeLists.txt
+++ b/lib/cpu/CMakeLists.txt
@@ -15,6 +15,12 @@ target_include_directories(
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
+target_link_libraries(
+    cpu
+    INTERFACE
+    covfie::core
+)
+
 target_compile_features(cpu INTERFACE cxx_std_17)
 
 # Logic to ensure that the CPU module can be installed properly.
@@ -30,3 +36,7 @@ install(
 
 # Hack for compatibility
 add_library(covfie::cpu ALIAS cpu)
+
+# Test the public headers of covfie::cpu.
+include(covfie-functions)
+covfie_test_public_headers(cpu "covfie/cpu/backend/primitive/c_array.hpp")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,8 +6,21 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 
-# All the tests here will require Google Test, so we will go ahead and find it.
-find_package(GTest CONFIG REQUIRED)
+# All the tests here will require Google Test, so we will go ahead and set it
+# up.
+# Set up GoogleTest.
+option(COVFIE_SETUP_GOOGLETEST "Set up the GoogleTest targets explicitly"
+    TRUE)
+option(COVFIE_USE_SYSTEM_GOOGLETEST
+    "Pick up an existing installation of GoogleTest from the build environment"
+    TRUE)
+if(COVFIE_SETUP_GOOGLETEST)
+    if(COVFIE_USE_SYSTEM_GOOGLETEST)
+        find_package(GTest CONFIG REQUIRED)
+    else()
+        add_subdirectory(googletest)
+    endif()
+endif()
 
 # Set up the C++ compiler flags for the tests.
 include(covfie-compiler-options-cpp)

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -1,20 +1,10 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022 CERN
+# Copyright (c) 2022-2023 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
-
-# We use the Boost filesystem for the creation of some temporary files, so
-# we'll load that as well.
-find_package(
-    Boost
-    1.71.0
-    REQUIRED
-    COMPONENTS
-    filesystem
-)
 
 # Create the test executable from the individual test groups.
 add_executable(
@@ -41,6 +31,5 @@ target_link_libraries(
     core
     GTest::gtest
     GTest::gtest_main
-    Boost::filesystem
     testing_utils
 )

--- a/tests/core/test_algebra.cpp
+++ b/tests/core/test_algebra.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -32,14 +32,14 @@ TEST(TestAlgebra, VectorArrayInit1D)
 {
     covfie::algebra::vector<1, double> v(std::array<double, 1>{21.5});
 
-    EXPECT_FLOAT_EQ(v(0), 21.5);
+    EXPECT_DOUBLE_EQ(v(0), 21.5);
 }
 
 TEST(TestAlgebra, VectorVariadicInit1D)
 {
     covfie::algebra::vector<1, double> v(84.2);
 
-    EXPECT_FLOAT_EQ(v(0), 84.2);
+    EXPECT_DOUBLE_EQ(v(0), 84.2);
 }
 
 TEST(TestAlgebra, VectorArrayInit2F)
@@ -62,16 +62,16 @@ TEST(TestAlgebra, VectorArrayInit2D)
 {
     covfie::algebra::vector<2, double> v(std::array<double, 2>{21.5, 11.8});
 
-    EXPECT_FLOAT_EQ(v(0), 21.5);
-    EXPECT_FLOAT_EQ(v(1), 11.8);
+    EXPECT_DOUBLE_EQ(v(0), 21.5);
+    EXPECT_DOUBLE_EQ(v(1), 11.8);
 }
 
 TEST(TestAlgebra, VectorVariadicInit2D)
 {
     covfie::algebra::vector<2, double> v(84.2, 77.3);
 
-    EXPECT_FLOAT_EQ(v(0), 84.2);
-    EXPECT_FLOAT_EQ(v(1), 77.3);
+    EXPECT_DOUBLE_EQ(v(0), 84.2);
+    EXPECT_DOUBLE_EQ(v(1), 77.3);
 }
 
 TEST(TestAlgebra, VectorArrayInit3F)
@@ -98,18 +98,18 @@ TEST(TestAlgebra, VectorArrayInit3D)
     covfie::algebra::vector<3, double> v(std::array<double, 3>{21.5, 11.8, 28.2}
     );
 
-    EXPECT_FLOAT_EQ(v(0), 21.5);
-    EXPECT_FLOAT_EQ(v(1), 11.8);
-    EXPECT_FLOAT_EQ(v(2), 28.2);
+    EXPECT_DOUBLE_EQ(v(0), 21.5);
+    EXPECT_DOUBLE_EQ(v(1), 11.8);
+    EXPECT_DOUBLE_EQ(v(2), 28.2);
 }
 
 TEST(TestAlgebra, VectorVariadicInit3D)
 {
     covfie::algebra::vector<3, double> v(84.2, 77.3, 66.1);
 
-    EXPECT_FLOAT_EQ(v(0), 84.2);
-    EXPECT_FLOAT_EQ(v(1), 77.3);
-    EXPECT_FLOAT_EQ(v(2), 66.1);
+    EXPECT_DOUBLE_EQ(v(0), 84.2);
+    EXPECT_DOUBLE_EQ(v(1), 77.3);
+    EXPECT_DOUBLE_EQ(v(2), 66.1);
 }
 
 TEST(TestAlgebra, VectorAssignment1F)
@@ -127,7 +127,7 @@ TEST(TestAlgebra, VectorAssignment1D)
 
     v(0) = 5.3;
 
-    EXPECT_FLOAT_EQ(v(0), 5.3);
+    EXPECT_DOUBLE_EQ(v(0), 5.3);
 }
 
 TEST(TestAlgebra, VectorAssignment2F)
@@ -148,8 +148,8 @@ TEST(TestAlgebra, VectorAssignment2D)
     v(0) = 5.3;
     v(1) = 5.5;
 
-    EXPECT_FLOAT_EQ(v(0), 5.3);
-    EXPECT_FLOAT_EQ(v(1), 5.5);
+    EXPECT_DOUBLE_EQ(v(0), 5.3);
+    EXPECT_DOUBLE_EQ(v(1), 5.5);
 }
 
 TEST(TestAlgebra, VectorAssignment3F)
@@ -173,9 +173,9 @@ TEST(TestAlgebra, VectorAssignment3D)
     v(1) = 6.3;
     v(2) = 7.3;
 
-    EXPECT_FLOAT_EQ(v(0), 5.3);
-    EXPECT_FLOAT_EQ(v(1), 6.3);
-    EXPECT_FLOAT_EQ(v(2), 7.3);
+    EXPECT_DOUBLE_EQ(v(0), 5.3);
+    EXPECT_DOUBLE_EQ(v(1), 6.3);
+    EXPECT_DOUBLE_EQ(v(2), 7.3);
 }
 
 TEST(TestAlgebra, MatrixInit1x1F)

--- a/tests/core/test_array_binary_io.cpp
+++ b/tests/core/test_array_binary_io.cpp
@@ -1,16 +1,16 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <filesystem>
 #include <fstream>
 
-#include <boost/filesystem.hpp>
 #include <gtest/gtest.h>
 #include <tmp_file.hpp>
 
@@ -33,7 +33,7 @@ TEST(TestArrayBinaryIO, WriteReadFloatFloat)
         p[0] = static_cast<float>(i);
     }
 
-    boost::filesystem::path ofile = get_tmp_file();
+    std::filesystem::path ofile = get_tmp_file();
 
     std::ofstream ofs(ofile.native(), std::ofstream::binary);
 
@@ -77,7 +77,7 @@ TEST(TestArrayBinaryIO, WriteReadDoubleDouble)
         p[0] = static_cast<double>(i);
     }
 
-    boost::filesystem::path ofile = get_tmp_file();
+    std::filesystem::path ofile = get_tmp_file();
 
     std::ofstream ofs(ofile.native(), std::ofstream::binary);
 
@@ -123,7 +123,7 @@ TEST(TestArrayBinaryIO, WriteReadFloatDouble)
         p[0] = static_cast<float>(i);
     }
 
-    boost::filesystem::path ofile = get_tmp_file();
+    std::filesystem::path ofile = get_tmp_file();
 
     std::ofstream ofs(ofile.native(), std::ofstream::binary);
 
@@ -169,7 +169,7 @@ TEST(TestArrayBinaryIO, WriteReadDoubleFloat)
         p[0] = static_cast<double>(i);
     }
 
-    boost::filesystem::path ofile = get_tmp_file();
+    std::filesystem::path ofile = get_tmp_file();
 
     std::ofstream ofs(ofile.native(), std::ofstream::binary);
 

--- a/tests/core/test_binary_io.cpp
+++ b/tests/core/test_binary_io.cpp
@@ -1,16 +1,16 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <filesystem>
 #include <fstream>
 
-#include <boost/filesystem.hpp>
 #include <gtest/gtest.h>
 #include <tmp_file.hpp>
 
@@ -32,7 +32,7 @@ TEST(TestBinaryIO, WriteRead1DSingleFloatBuilder)
         p[0] = static_cast<float>(i);
     }
 
-    boost::filesystem::path ofile = get_tmp_file();
+    std::filesystem::path ofile = get_tmp_file();
 
     std::ofstream ofs(ofile.native(), std::ofstream::binary);
 

--- a/tests/cpu/test_cpu_array_backend.cpp
+++ b/tests/cpu/test_cpu_array_backend.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -32,13 +32,13 @@ TEST(TestFieldViewCPUArrayBackend, WriteRead1DSingleFloat)
 
     for (std::size_t x = 0; x < 5; ++x) {
         for (std::size_t j = 0; j < 1; ++j) {
-            fv.at(x)[j] = 1000. * x + 1. * j;
+            fv.at(x)[j] = 1000.f * x + 1.f * j;
         }
     }
 
     for (std::size_t x = 0; x < 5; ++x) {
         for (std::size_t j = 0; j < 1; ++j) {
-            EXPECT_EQ(fv.at(x)[j], 1000. * x + 1. * j);
+            EXPECT_EQ(fv.at(x)[j], 1000.f * x + 1.f * j);
         }
     }
 }
@@ -55,13 +55,13 @@ TEST(TestFieldViewCPUArrayBackend, WriteRead1DArrayFloat)
 
     for (std::size_t x = 0; x < 5; ++x) {
         for (std::size_t j = 0; j < 3; ++j) {
-            fv.at(x)[j] = 1000. * x + 1. * j;
+            fv.at(x)[j] = 1000.f * x + 1.f * j;
         }
     }
 
     for (std::size_t x = 0; x < 5; ++x) {
         for (std::size_t j = 0; j < 3; ++j) {
-            EXPECT_EQ(fv.at(x)[j], 1000. * x + 1. * j);
+            EXPECT_EQ(fv.at(x)[j], 1000.f * x + 1.f * j);
         }
     }
 }
@@ -79,7 +79,7 @@ TEST(TestFieldViewCPUArrayBackend, WriteRead2DSingleFloat)
     for (std::size_t x = 0; x < 5; ++x) {
         for (std::size_t y = 0; y < 7; ++y) {
             for (std::size_t j = 0; j < 1; ++j) {
-                fv.at(x, y)[j] = 1000. * x + 100. * y + 1. * j;
+                fv.at(x, y)[j] = 1000.f * x + 100.f * y + 1.f * j;
             }
         }
     }
@@ -87,7 +87,7 @@ TEST(TestFieldViewCPUArrayBackend, WriteRead2DSingleFloat)
     for (std::size_t x = 0; x < 5; ++x) {
         for (std::size_t y = 0; y < 7; ++y) {
             for (std::size_t j = 0; j < 1; ++j) {
-                EXPECT_EQ(fv.at(x, y)[j], 1000. * x + 100. * y + 1. * j);
+                EXPECT_EQ(fv.at(x, y)[j], 1000.f * x + 100.f * y + 1.f * j);
             }
         }
     }
@@ -106,7 +106,7 @@ TEST(TestFieldViewCPUArrayBackend, WriteRead2DArrayFloat)
     for (std::size_t x = 0; x < 5; ++x) {
         for (std::size_t y = 0; y < 7; ++y) {
             for (std::size_t j = 0; j < 3; ++j) {
-                fv.at(x, y)[j] = 1000. * x + 100. * y + 1. * j;
+                fv.at(x, y)[j] = 1000.f * x + 100.f * y + 1.f * j;
             }
         }
     }
@@ -114,7 +114,7 @@ TEST(TestFieldViewCPUArrayBackend, WriteRead2DArrayFloat)
     for (std::size_t x = 0; x < 5; ++x) {
         for (std::size_t y = 0; y < 7; ++y) {
             for (std::size_t j = 0; j < 3; ++j) {
-                EXPECT_EQ(fv.at(x, y)[j], 1000. * x + 100. * y + 1. * j);
+                EXPECT_EQ(fv.at(x, y)[j], 1000.f * x + 100.f * y + 1.f * j);
             }
         }
     }
@@ -134,7 +134,8 @@ TEST(TestFieldViewCPUArrayBackend, WriteRead3DSingleFloat)
         for (std::size_t y = 0; y < 7; ++y) {
             for (std::size_t z = 0; z < 2; ++z) {
                 for (std::size_t j = 0; j < 1; ++j) {
-                    fv.at(x, y, z)[j] = 1000. * x + 100. * y + 10. * z + 1. * j;
+                    fv.at(x, y, z)[j] =
+                        1000.f * x + 100.f * y + 10.f * z + 1.f * j;
                 }
             }
         }
@@ -146,7 +147,7 @@ TEST(TestFieldViewCPUArrayBackend, WriteRead3DSingleFloat)
                 for (std::size_t j = 0; j < 1; ++j) {
                     EXPECT_EQ(
                         fv.at(x, y, z)[j],
-                        1000. * x + 100. * y + 10. * z + 1. * j
+                        1000.f * x + 100.f * y + 10.f * z + 1.f * j
                     );
                 }
             }
@@ -168,7 +169,8 @@ TEST(TestFieldViewCPUArrayBackend, WriteRead3DArrayFloat)
         for (std::size_t y = 0; y < 7; ++y) {
             for (std::size_t z = 0; z < 2; ++z) {
                 for (std::size_t j = 0; j < 3; ++j) {
-                    fv.at(x, y, z)[j] = 1000. * x + 100. * y + 10. * z + 1. * j;
+                    fv.at(x, y, z)[j] =
+                        1000.f * x + 100.f * y + 10.f * z + 1.f * j;
                 }
             }
         }
@@ -180,7 +182,7 @@ TEST(TestFieldViewCPUArrayBackend, WriteRead3DArrayFloat)
                 for (std::size_t j = 0; j < 3; ++j) {
                     EXPECT_EQ(
                         fv.at(x, y, z)[j],
-                        1000. * x + 100. * y + 10. * z + 1. * j
+                        1000.f * x + 100.f * y + 10.f * z + 1.f * j
                     );
                 }
             }

--- a/tests/googletest/CMakeLists.txt
+++ b/tests/googletest/CMakeLists.txt
@@ -1,0 +1,45 @@
+# This file is part of covfie, a part of the ACTS project
+#
+# Copyright (c) 2023 CERN
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+# CMake include(s).
+cmake_minimum_required( VERSION 3.11 )
+include( FetchContent )
+
+# Silence FetchContent warnings with CMake >=3.24.
+if(POLICY CMP0135)
+   cmake_policy(SET CMP0135 NEW)
+endif()
+
+# Tell the user what's happening.
+message(STATUS "Building GoogleTest as part of the Covfie project")
+
+# Declare where to get GoogleTest from.
+FetchContent_Declare(GoogleTest
+   URL "https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz"
+   URL_MD5 "c8340a482851ef6a3fe618a082304cfc")
+
+# Options used in the build of GoogleTest.
+set(BUILD_GMOCK FALSE CACHE BOOL "Turn off the build of GMock")
+set(INSTALL_GTEST FALSE CACHE BOOL "Turn off the installation of GoogleTest")
+if( WIN32 )
+   set(gtest_force_shared_crt TRUE CACHE BOOL
+       "Use shared (DLL) run-time library, even with static libraries")
+endif()
+
+# Silence some warnings with modern versions of CMake on macOS.
+set(CMAKE_MACOSX_RPATH TRUE)
+
+# Get it into the current directory.
+FetchContent_Populate( GoogleTest )
+add_subdirectory("${googletest_SOURCE_DIR}" "${googletest_BINARY_DIR}"
+   EXCLUDE_FROM_ALL)
+
+# Set up aliases for the GTest targets with the same name that they have
+# when we find GTest pre-installed.
+add_library(GTest::gtest ALIAS gtest)
+add_library(GTest::gtest_main ALIAS gtest_main)

--- a/tests/googletest/README.md
+++ b/tests/googletest/README.md
@@ -1,0 +1,10 @@
+# GoogleTest Build Instructions
+
+This subdirectory holds instructions for building
+[GoogleTest](https://github.com/google/googletest) as part of this project.
+This is meant to come in handy for building the project's tests in environments
+which do not provide GoogleTest themselves.
+
+Note that since GoogleTest is only needed for the unit tests of this project,
+which are not installed together with the project, GoogleTest is not installed
+together with the project either.

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -1,18 +1,10 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022 CERN
+# Copyright (c) 2022-2023 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
-
-find_package(
-    Boost
-    1.71.0
-    REQUIRED
-    COMPONENTS
-    filesystem
-)
 
 add_library(
     testing_utils
@@ -20,17 +12,15 @@ add_library(
     tmp_file.cpp
 )
 
-# Ensure that the utils.
-target_link_libraries(
-    testing_utils
-
-    PUBLIC
-    Boost::filesystem
-)
-
 target_include_directories(
     testing_utils
     PUBLIC
 
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+target_compile_definitions(
+    testing_utils
+    PRIVATE
+    _CRT_SECURE_NO_WARNINGS
 )

--- a/tests/utils/tmp_file.cpp
+++ b/tests/utils/tmp_file.cpp
@@ -1,20 +1,24 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <boost/filesystem.hpp>
+// Local include(s).
 #include <tmp_file.hpp>
 
-boost::filesystem::path get_tmp_file()
+// System include(s).
+#include <cstdio>
+
+std::filesystem::path get_tmp_file()
 {
-    return boost::filesystem::temp_directory_path() /
-           boost::filesystem::unique_path(
-               "covfie_test_%%%%_%%%%_%%%%_%%%%.covfie"
-           );
+    char fname[L_tmpnam];
+    char* dummy = std::tmpnam(fname);
+    (void)dummy;
+    return std::filesystem::temp_directory_path() /
+           std::filesystem::path(fname);
 }

--- a/tests/utils/tmp_file.cpp
+++ b/tests/utils/tmp_file.cpp
@@ -17,7 +17,7 @@
 std::filesystem::path get_tmp_file()
 {
     char fname[L_tmpnam];
-    char* dummy = std::tmpnam(fname);
+    char * dummy = std::tmpnam(fname);
     (void)dummy;
     return std::filesystem::temp_directory_path() /
            std::filesystem::path(fname);

--- a/tests/utils/tmp_file.hpp
+++ b/tests/utils/tmp_file.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -10,6 +10,6 @@
 
 #pragma once
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
-boost::filesystem::path get_tmp_file();
+std::filesystem::path get_tmp_file();


### PR DESCRIPTION
Since I quickly realized while working with Detray that this project's code will still need some work for Windows compatibility, I went ahead and set up the basic ability to perform a Windows based build. But this just opened can of worms... :frowning:

I tried to set up the same sort of header tests for this project that we have in the other R&D projects as well. Which would make sure that the headers include everything that they need, and that the CMake targets are configured correctly. But this quickly resulted in:

```
[ 18%] Building CXX object lib/core/CMakeFiles/test_core_covfie_core_backend_transformer_backup_hpp.dir/CMakeFiles/test_core_covfie_core_backend_transformer_backup_hpp.cpp.o
In file included from /data/ssd-1tb/projects/covfie/build/lib/core/CMakeFiles/test_core_covfie_core_backend_transformer_backup_hpp.cpp:1:
/data/ssd-1tb/projects/covfie/covfie/lib/core/covfie/core/backend/transformer/backup.hpp: In static member function ‘static void covfie::backend::backup<_backend_t>::owning_data_t::write_binary(std::ostream&, const covfie::backend::backup<_backend_t>::owning_data_t&)’:
/data/ssd-1tb/projects/covfie/covfie/lib/core/covfie/core/backend/transformer/backup.hpp:124:49: error: invalid use of member ‘covfie::backend::backup<_backend_t>::owning_data_t::m_min’ in static member function
  124 |                 reinterpret_cast<const char *>(&m_min), sizeof(decltype(m_min))
      |                                                 ^~~~~
/data/ssd-1tb/projects/covfie/covfie/lib/core/covfie/core/backend/transformer/backup.hpp:139:50: note: declared here
  139 |         typename contravariant_input_t::vector_t m_min, m_max;
      |                                                  ^~~~~
/data/ssd-1tb/projects/covfie/covfie/lib/core/covfie/core/backend/transformer/backup.hpp:127:49: error: invalid use of member ‘covfie::backend::backup<_backend_t>::owning_data_t::m_max’ in static member function
  127 |                 reinterpret_cast<const char *>(&m_max), sizeof(decltype(m_max))
      |                                                 ^~~~~
/data/ssd-1tb/projects/covfie/covfie/lib/core/covfie/core/backend/transformer/backup.hpp:139:57: note: declared here
  139 |         typename contravariant_input_t::vector_t m_min, m_max;
      |                                                         ^~~~~
/data/ssd-1tb/projects/covfie/covfie/lib/core/covfie/core/backend/transformer/backup.hpp:130:49: error: invalid use of member ‘covfie::backend::backup<_backend_t>::owning_data_t::m_default’ in static member function
  130 |                 reinterpret_cast<const char *>(&m_default),
      |                                                 ^~~~~~~~~
/data/ssd-1tb/projects/covfie/covfie/lib/core/covfie/core/backend/transformer/backup.hpp:140:47: note: declared here
  140 |         typename covariant_output_t::vector_t m_default;
      |                                               ^~~~~~~~~
make[2]: *** [lib/core/CMakeFiles/test_core_covfie_core_backend_transformer_backup_hpp.dir/build.make:76: lib/core/CMakeFiles/test_core_covfie_core_backend_transformer_backup_hpp.dir/CMakeFiles/test_core_covfie_core_backend_transformer_backup_hpp.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:524: lib/core/CMakeFiles/test_core_covfie_core_backend_transformer_backup_hpp.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

Which is a fundamental enough issue that I'd not want to sort it out in this PR. (Is that file used anywhere? I guess not.)

But at least I went through the unit tests, and made sure that those would all compile without warnings with MSVC. And to think that I was really just trying to replace `uint` with `unsigned int` when I started with this all...

P.S. The CUDA test on Windows just refuses to build. :frowning: But I gave up on it for today...