### PR TITLE
Add additional core library build tests

### DIFF
--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(
     test_static_permutation.cpp
     test_utility_numeric.cpp
     test_array_binary_io.cpp
+    test_build.cpp
 )
 
 # Ensure that the tests are linked against the required libraries.

--- a/tests/core/test_build.cpp
+++ b/tests/core/test_build.cpp
@@ -1,0 +1,37 @@
+/*
+ * This file is part of covfie, a part of the ACTS project
+ *
+ * Copyright (c) 2022 CERN
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <covfie/core/backend/primitive/identity.hpp>
+#include <covfie/core/backend/transformer/affine.hpp>
+#include <covfie/core/backend/transformer/backup.hpp>
+#include <covfie/core/backend/transformer/clamp.hpp>
+#include <covfie/core/backend/transformer/hilbert.hpp>
+#include <covfie/core/backend/transformer/linear.hpp>
+#include <covfie/core/backend/transformer/morton.hpp>
+#include <covfie/core/backend/transformer/nearest_neighbour.hpp>
+#include <covfie/core/backend/transformer/shuffle.hpp>
+#include <covfie/core/backend/transformer/strided.hpp>
+#include <covfie/core/field.hpp>
+
+using base_field = covfie::backend::identity<covfie::vector::uint1>;
+
+template class covfie::field<covfie::backend::affine<base_field>>;
+template class covfie::field<covfie::backend::backup<base_field>>;
+template class covfie::field<covfie::backend::clamp<base_field>>;
+template class covfie::field<
+    covfie::backend::hilbert<covfie::vector::uint2, base_field>>;
+template class covfie::field<covfie::backend::linear<base_field>>;
+template class covfie::field<
+    covfie::backend::morton<covfie::vector::uint2, base_field>>;
+template class covfie::field<covfie::backend::nearest_neighbour<base_field>>;
+template class covfie::field<
+    covfie::backend::shuffle<base_field, std::index_sequence<0>>>;
+template class covfie::field<
+    covfie::backend::strided<covfie::vector::uint2, base_field>>;


### PR DESCRIPTION
This commit adds some explicit template instantiations to ensure that concepts hold and that things can be compiled succesfully.