### PR TITLE
Add missing CMake interface libraries

### DIFF
--- a/lib/cpu/CMakeLists.txt
+++ b/lib/cpu/CMakeLists.txt
@@ -28,5 +28,11 @@ install(
     DESTINATION include
 )
 
+target_link_libraries(
+    cpu
+    INTERFACE
+    covfie::core
+)
+
 # Hack for compatibility
 add_library(covfie::cpu ALIAS cpu)

--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(
     cuda
     INTERFACE
     CUDA::cudart
+    covfie::core
 )
 
 # Logic to ensure that the CUDA module can be installed properly.


### PR DESCRIPTION
The CPU and CUDA libraries were previously not being linked against the core library which they should be. This commit resolves that problem.