### PR TITLE
Make public headers work standalone

### DIFF
--- a/lib/core/covfie/core/backend/transformer/dereference.hpp
+++ b/lib/core/covfie/core/backend/transformer/dereference.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -12,6 +12,12 @@
 
 #include <iostream>
 #include <variant>
+
+#include <covfie/core/concepts.hpp>
+#include <covfie/core/definitions.hpp>
+#include <covfie/core/qualifiers.hpp>
+#include <covfie/core/utility/binary_io.hpp>
+#include <covfie/core/vector.hpp>
 
 namespace covfie::backend {
 template <CONSTRAINT(concepts::field_backend) _backend_t>

--- a/lib/core/covfie/core/backend/transformer/hilbert.hpp
+++ b/lib/core/covfie/core/backend/transformer/hilbert.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/backend/transformer/linear.hpp
+++ b/lib/core/covfie/core/backend/transformer/linear.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -18,6 +18,7 @@
 
 #include <covfie/core/concepts.hpp>
 #include <covfie/core/qualifiers.hpp>
+#include <covfie/core/utility/binary_io.hpp>
 #include <covfie/core/vector.hpp>
 
 namespace covfie::backend {

--- a/lib/core/covfie/core/backend/transformer/nearest_neighbour.hpp
+++ b/lib/core/covfie/core/backend/transformer/nearest_neighbour.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -17,7 +17,10 @@
 #include <variant>
 
 #include <covfie/core/concepts.hpp>
+#include <covfie/core/definitions.hpp>
+#include <covfie/core/parameter_pack.hpp>
 #include <covfie/core/qualifiers.hpp>
+#include <covfie/core/utility/binary_io.hpp>
 #include <covfie/core/vector.hpp>
 
 namespace covfie::backend {

--- a/lib/core/covfie/core/backend/transformer/shuffle.hpp
+++ b/lib/core/covfie/core/backend/transformer/shuffle.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -12,6 +12,11 @@
 
 #include <iostream>
 #include <variant>
+
+#include <covfie/core/concepts.hpp>
+#include <covfie/core/definitions.hpp>
+#include <covfie/core/qualifiers.hpp>
+#include <covfie/core/utility/binary_io.hpp>
 
 namespace covfie::backend {
 template <CONSTRAINT(concepts::field_backend) _backend_t, typename _shuffle>

--- a/lib/core/covfie/core/parameter_pack.hpp
+++ b/lib/core/covfie/core/parameter_pack.hpp
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <utility>
+
 namespace covfie {
 template <typename... Ts>
 class parameter_pack

--- a/lib/core/covfie/core/utility/nd_map.hpp
+++ b/lib/core/covfie/core/utility/nd_map.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -12,6 +12,7 @@
 
 #include <array>
 #include <functional>
+#include <tuple>
 
 namespace covfie::utility {
 template <std::size_t... Ns, typename... Ts>

--- a/lib/cuda/covfie/cuda/error_check.hpp
+++ b/lib/cuda/covfie/cuda/error_check.hpp
@@ -12,6 +12,8 @@
 
 #include <sstream>
 
+#include <cuda_runtime_api.h>
+
 #define cudaErrorCheck(r)                                                      \
     {                                                                          \
         _cudaErrorCheck((r), __FILE__, __LINE__);                              \


### PR DESCRIPTION
This commit ensures that the headers in the core, CPU, and CUDA plugins can be compiled stand-alone, preventing nasty surprises for users.