### PR TITLE
Replace `boost::filesystem` by `std::filesystem`

### DIFF
--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -1,20 +1,10 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022 CERN
+# Copyright (c) 2022-2023 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
-
-# We use the Boost filesystem for the creation of some temporary files, so
-# we'll load that as well.
-find_package(
-    Boost
-    1.71.0
-    REQUIRED
-    COMPONENTS
-    filesystem
-)
 
 # Create the test executable from the individual test groups.
 add_executable(
@@ -42,6 +32,5 @@ target_link_libraries(
     core
     GTest::gtest
     GTest::gtest_main
-    Boost::filesystem
     testing_utils
 )

--- a/tests/core/test_array_binary_io.cpp
+++ b/tests/core/test_array_binary_io.cpp
@@ -1,16 +1,16 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <filesystem>
 #include <fstream>
 
-#include <boost/filesystem.hpp>
 #include <gtest/gtest.h>
 #include <tmp_file.hpp>
 
@@ -33,7 +33,7 @@ TEST(TestArrayBinaryIO, WriteReadFloatFloat)
         p[0] = static_cast<float>(i);
     }
 
-    boost::filesystem::path ofile = get_tmp_file();
+    std::filesystem::path ofile = get_tmp_file();
 
     std::ofstream ofs(ofile.native(), std::ofstream::binary);
 
@@ -77,7 +77,7 @@ TEST(TestArrayBinaryIO, WriteReadDoubleDouble)
         p[0] = static_cast<double>(i);
     }
 
-    boost::filesystem::path ofile = get_tmp_file();
+    std::filesystem::path ofile = get_tmp_file();
 
     std::ofstream ofs(ofile.native(), std::ofstream::binary);
 
@@ -123,7 +123,7 @@ TEST(TestArrayBinaryIO, WriteReadFloatDouble)
         p[0] = static_cast<float>(i);
     }
 
-    boost::filesystem::path ofile = get_tmp_file();
+    std::filesystem::path ofile = get_tmp_file();
 
     std::ofstream ofs(ofile.native(), std::ofstream::binary);
 
@@ -169,7 +169,7 @@ TEST(TestArrayBinaryIO, WriteReadDoubleFloat)
         p[0] = static_cast<double>(i);
     }
 
-    boost::filesystem::path ofile = get_tmp_file();
+    std::filesystem::path ofile = get_tmp_file();
 
     std::ofstream ofs(ofile.native(), std::ofstream::binary);
 

--- a/tests/core/test_binary_io.cpp
+++ b/tests/core/test_binary_io.cpp
@@ -1,16 +1,16 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <filesystem>
 #include <fstream>
 
-#include <boost/filesystem.hpp>
 #include <gtest/gtest.h>
 #include <tmp_file.hpp>
 
@@ -32,7 +32,7 @@ TEST(TestBinaryIO, WriteRead1DSingleFloatBuilder)
         p[0] = static_cast<float>(i);
     }
 
-    boost::filesystem::path ofile = get_tmp_file();
+    std::filesystem::path ofile = get_tmp_file();
 
     std::ofstream ofs(ofile.native(), std::ofstream::binary);
 

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -1,31 +1,15 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022 CERN
+# Copyright (c) 2022-2023 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 
-find_package(
-    Boost
-    1.71.0
-    REQUIRED
-    COMPONENTS
-    filesystem
-)
-
 add_library(
     testing_utils
 
     tmp_file.cpp
-)
-
-# Ensure that the utils.
-target_link_libraries(
-    testing_utils
-
-    PUBLIC
-    Boost::filesystem
 )
 
 target_include_directories(

--- a/tests/utils/tmp_file.cpp
+++ b/tests/utils/tmp_file.cpp
@@ -1,20 +1,24 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <boost/filesystem.hpp>
+// Local include(s).
 #include <tmp_file.hpp>
 
-boost::filesystem::path get_tmp_file()
+// System include(s).
+#include <cstdio>
+
+std::filesystem::path get_tmp_file()
 {
-    return boost::filesystem::temp_directory_path() /
-           boost::filesystem::unique_path(
-               "covfie_test_%%%%_%%%%_%%%%_%%%%.covfie"
-           );
+    char fname[L_tmpnam];
+    char * dummy = std::tmpnam(fname);
+    (void)dummy;
+    return std::filesystem::temp_directory_path() /
+           std::filesystem::path(fname);
 }

--- a/tests/utils/tmp_file.hpp
+++ b/tests/utils/tmp_file.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022 CERN
+ * Copyright (c) 2022-2023 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -10,6 +10,6 @@
 
 #pragma once
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
-boost::filesystem::path get_tmp_file();
+std::filesystem::path get_tmp_file();


### PR DESCRIPTION
This commit replaces the usage of `boost::filesystem` by (nearly) equivalent functions from `std::filesystem` in the testing code.