### PR TITLE
Add `make_parameter_pack_for` utility function

### DIFF
--- a/extra/parameter_pack_gen/gen_parameter_pack_code.py
+++ b/extra/parameter_pack_gen/gen_parameter_pack_code.py
@@ -1,0 +1,8 @@
+if __name__ == "__main__":
+    for n in range(1, 11):
+        print(f"template <typename F, std::enable_if_t<utility::backend_depth<typename F::backend_t>::value == {n}, bool> = true> auto make_parameter_pack_for(")
+        print(",".join(f"typename utility::nth_backend<typename F::backend_t, {i}>::type::configuration_t && a{i}" for i in range(n)))
+        print(") { return make_parameter_pack(")
+        print(",".join(f"std::forward<typename utility::nth_backend<typename F::backend_t, {i}>::type::configuration_t>(a{i})" for i in range(n)))
+        print(");}")
+        print()

--- a/lib/core/covfie/core/parameter_pack.hpp
+++ b/lib/core/covfie/core/parameter_pack.hpp
@@ -12,6 +12,8 @@
 
 #include <utility>
 
+#include <covfie/core/utility/backend_traits.hpp>
+
 namespace covfie {
 template <typename... Ts>
 class parameter_pack
@@ -45,5 +47,347 @@ template <typename... Ts>
 parameter_pack<Ts...> make_parameter_pack(Ts &&... args)
 {
     return parameter_pack<Ts...>(std::forward<Ts>(args)...);
+}
+
+// WARNING: These functions are automatically generated. Best not edit them
+// by hand.
+
+template <
+    typename F,
+    std::enable_if_t<
+        utility::backend_depth<typename F::backend_t>::value == 1,
+        bool> = true>
+auto make_parameter_pack_for(typename utility::nth_backend<
+                             typename F::backend_t,
+                             0>::type::configuration_t && a0)
+{
+    return make_parameter_pack(
+        std::forward<typename utility::nth_backend<typename F::backend_t, 0>::
+                         type::configuration_t>(a0)
+    );
+}
+
+template <
+    typename F,
+    std::enable_if_t<
+        utility::backend_depth<typename F::backend_t>::value == 2,
+        bool> = true>
+auto make_parameter_pack_for(
+    typename utility::nth_backend<typename F::backend_t, 0>::type::
+        configuration_t && a0,
+    typename utility::nth_backend<typename F::backend_t, 1>::type::
+        configuration_t && a1
+)
+{
+    return make_parameter_pack(
+        std::forward<typename utility::nth_backend<typename F::backend_t, 0>::
+                         type::configuration_t>(a0),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 1>::
+                         type::configuration_t>(a1)
+    );
+}
+
+template <
+    typename F,
+    std::enable_if_t<
+        utility::backend_depth<typename F::backend_t>::value == 3,
+        bool> = true>
+auto make_parameter_pack_for(
+    typename utility::nth_backend<typename F::backend_t, 0>::type::
+        configuration_t && a0,
+    typename utility::nth_backend<typename F::backend_t, 1>::type::
+        configuration_t && a1,
+    typename utility::nth_backend<typename F::backend_t, 2>::type::
+        configuration_t && a2
+)
+{
+    return make_parameter_pack(
+        std::forward<typename utility::nth_backend<typename F::backend_t, 0>::
+                         type::configuration_t>(a0),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 1>::
+                         type::configuration_t>(a1),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 2>::
+                         type::configuration_t>(a2)
+    );
+}
+
+template <
+    typename F,
+    std::enable_if_t<
+        utility::backend_depth<typename F::backend_t>::value == 4,
+        bool> = true>
+auto make_parameter_pack_for(
+    typename utility::nth_backend<typename F::backend_t, 0>::type::
+        configuration_t && a0,
+    typename utility::nth_backend<typename F::backend_t, 1>::type::
+        configuration_t && a1,
+    typename utility::nth_backend<typename F::backend_t, 2>::type::
+        configuration_t && a2,
+    typename utility::nth_backend<typename F::backend_t, 3>::type::
+        configuration_t && a3
+)
+{
+    return make_parameter_pack(
+        std::forward<typename utility::nth_backend<typename F::backend_t, 0>::
+                         type::configuration_t>(a0),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 1>::
+                         type::configuration_t>(a1),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 2>::
+                         type::configuration_t>(a2),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 3>::
+                         type::configuration_t>(a3)
+    );
+}
+
+template <
+    typename F,
+    std::enable_if_t<
+        utility::backend_depth<typename F::backend_t>::value == 5,
+        bool> = true>
+auto make_parameter_pack_for(
+    typename utility::nth_backend<typename F::backend_t, 0>::type::
+        configuration_t && a0,
+    typename utility::nth_backend<typename F::backend_t, 1>::type::
+        configuration_t && a1,
+    typename utility::nth_backend<typename F::backend_t, 2>::type::
+        configuration_t && a2,
+    typename utility::nth_backend<typename F::backend_t, 3>::type::
+        configuration_t && a3,
+    typename utility::nth_backend<typename F::backend_t, 4>::type::
+        configuration_t && a4
+)
+{
+    return make_parameter_pack(
+        std::forward<typename utility::nth_backend<typename F::backend_t, 0>::
+                         type::configuration_t>(a0),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 1>::
+                         type::configuration_t>(a1),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 2>::
+                         type::configuration_t>(a2),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 3>::
+                         type::configuration_t>(a3),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 4>::
+                         type::configuration_t>(a4)
+    );
+}
+
+template <
+    typename F,
+    std::enable_if_t<
+        utility::backend_depth<typename F::backend_t>::value == 6,
+        bool> = true>
+auto make_parameter_pack_for(
+    typename utility::nth_backend<typename F::backend_t, 0>::type::
+        configuration_t && a0,
+    typename utility::nth_backend<typename F::backend_t, 1>::type::
+        configuration_t && a1,
+    typename utility::nth_backend<typename F::backend_t, 2>::type::
+        configuration_t && a2,
+    typename utility::nth_backend<typename F::backend_t, 3>::type::
+        configuration_t && a3,
+    typename utility::nth_backend<typename F::backend_t, 4>::type::
+        configuration_t && a4,
+    typename utility::nth_backend<typename F::backend_t, 5>::type::
+        configuration_t && a5
+)
+{
+    return make_parameter_pack(
+        std::forward<typename utility::nth_backend<typename F::backend_t, 0>::
+                         type::configuration_t>(a0),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 1>::
+                         type::configuration_t>(a1),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 2>::
+                         type::configuration_t>(a2),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 3>::
+                         type::configuration_t>(a3),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 4>::
+                         type::configuration_t>(a4),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 5>::
+                         type::configuration_t>(a5)
+    );
+}
+
+template <
+    typename F,
+    std::enable_if_t<
+        utility::backend_depth<typename F::backend_t>::value == 7,
+        bool> = true>
+auto make_parameter_pack_for(
+    typename utility::nth_backend<typename F::backend_t, 0>::type::
+        configuration_t && a0,
+    typename utility::nth_backend<typename F::backend_t, 1>::type::
+        configuration_t && a1,
+    typename utility::nth_backend<typename F::backend_t, 2>::type::
+        configuration_t && a2,
+    typename utility::nth_backend<typename F::backend_t, 3>::type::
+        configuration_t && a3,
+    typename utility::nth_backend<typename F::backend_t, 4>::type::
+        configuration_t && a4,
+    typename utility::nth_backend<typename F::backend_t, 5>::type::
+        configuration_t && a5,
+    typename utility::nth_backend<typename F::backend_t, 6>::type::
+        configuration_t && a6
+)
+{
+    return make_parameter_pack(
+        std::forward<typename utility::nth_backend<typename F::backend_t, 0>::
+                         type::configuration_t>(a0),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 1>::
+                         type::configuration_t>(a1),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 2>::
+                         type::configuration_t>(a2),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 3>::
+                         type::configuration_t>(a3),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 4>::
+                         type::configuration_t>(a4),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 5>::
+                         type::configuration_t>(a5),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 6>::
+                         type::configuration_t>(a6)
+    );
+}
+
+template <
+    typename F,
+    std::enable_if_t<
+        utility::backend_depth<typename F::backend_t>::value == 8,
+        bool> = true>
+auto make_parameter_pack_for(
+    typename utility::nth_backend<typename F::backend_t, 0>::type::
+        configuration_t && a0,
+    typename utility::nth_backend<typename F::backend_t, 1>::type::
+        configuration_t && a1,
+    typename utility::nth_backend<typename F::backend_t, 2>::type::
+        configuration_t && a2,
+    typename utility::nth_backend<typename F::backend_t, 3>::type::
+        configuration_t && a3,
+    typename utility::nth_backend<typename F::backend_t, 4>::type::
+        configuration_t && a4,
+    typename utility::nth_backend<typename F::backend_t, 5>::type::
+        configuration_t && a5,
+    typename utility::nth_backend<typename F::backend_t, 6>::type::
+        configuration_t && a6,
+    typename utility::nth_backend<typename F::backend_t, 7>::type::
+        configuration_t && a7
+)
+{
+    return make_parameter_pack(
+        std::forward<typename utility::nth_backend<typename F::backend_t, 0>::
+                         type::configuration_t>(a0),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 1>::
+                         type::configuration_t>(a1),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 2>::
+                         type::configuration_t>(a2),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 3>::
+                         type::configuration_t>(a3),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 4>::
+                         type::configuration_t>(a4),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 5>::
+                         type::configuration_t>(a5),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 6>::
+                         type::configuration_t>(a6),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 7>::
+                         type::configuration_t>(a7)
+    );
+}
+
+template <
+    typename F,
+    std::enable_if_t<
+        utility::backend_depth<typename F::backend_t>::value == 9,
+        bool> = true>
+auto make_parameter_pack_for(
+    typename utility::nth_backend<typename F::backend_t, 0>::type::
+        configuration_t && a0,
+    typename utility::nth_backend<typename F::backend_t, 1>::type::
+        configuration_t && a1,
+    typename utility::nth_backend<typename F::backend_t, 2>::type::
+        configuration_t && a2,
+    typename utility::nth_backend<typename F::backend_t, 3>::type::
+        configuration_t && a3,
+    typename utility::nth_backend<typename F::backend_t, 4>::type::
+        configuration_t && a4,
+    typename utility::nth_backend<typename F::backend_t, 5>::type::
+        configuration_t && a5,
+    typename utility::nth_backend<typename F::backend_t, 6>::type::
+        configuration_t && a6,
+    typename utility::nth_backend<typename F::backend_t, 7>::type::
+        configuration_t && a7,
+    typename utility::nth_backend<typename F::backend_t, 8>::type::
+        configuration_t && a8
+)
+{
+    return make_parameter_pack(
+        std::forward<typename utility::nth_backend<typename F::backend_t, 0>::
+                         type::configuration_t>(a0),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 1>::
+                         type::configuration_t>(a1),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 2>::
+                         type::configuration_t>(a2),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 3>::
+                         type::configuration_t>(a3),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 4>::
+                         type::configuration_t>(a4),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 5>::
+                         type::configuration_t>(a5),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 6>::
+                         type::configuration_t>(a6),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 7>::
+                         type::configuration_t>(a7),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 8>::
+                         type::configuration_t>(a8)
+    );
+}
+
+template <
+    typename F,
+    std::enable_if_t<
+        utility::backend_depth<typename F::backend_t>::value == 10,
+        bool> = true>
+auto make_parameter_pack_for(
+    typename utility::nth_backend<typename F::backend_t, 0>::type::
+        configuration_t && a0,
+    typename utility::nth_backend<typename F::backend_t, 1>::type::
+        configuration_t && a1,
+    typename utility::nth_backend<typename F::backend_t, 2>::type::
+        configuration_t && a2,
+    typename utility::nth_backend<typename F::backend_t, 3>::type::
+        configuration_t && a3,
+    typename utility::nth_backend<typename F::backend_t, 4>::type::
+        configuration_t && a4,
+    typename utility::nth_backend<typename F::backend_t, 5>::type::
+        configuration_t && a5,
+    typename utility::nth_backend<typename F::backend_t, 6>::type::
+        configuration_t && a6,
+    typename utility::nth_backend<typename F::backend_t, 7>::type::
+        configuration_t && a7,
+    typename utility::nth_backend<typename F::backend_t, 8>::type::
+        configuration_t && a8,
+    typename utility::nth_backend<typename F::backend_t, 9>::type::
+        configuration_t && a9
+)
+{
+    return make_parameter_pack(
+        std::forward<typename utility::nth_backend<typename F::backend_t, 0>::
+                         type::configuration_t>(a0),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 1>::
+                         type::configuration_t>(a1),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 2>::
+                         type::configuration_t>(a2),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 3>::
+                         type::configuration_t>(a3),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 4>::
+                         type::configuration_t>(a4),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 5>::
+                         type::configuration_t>(a5),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 6>::
+                         type::configuration_t>(a6),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 7>::
+                         type::configuration_t>(a7),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 8>::
+                         type::configuration_t>(a8),
+        std::forward<typename utility::nth_backend<typename F::backend_t, 9>::
+                         type::configuration_t>(a9)
+    );
 }
 }

--- a/lib/core/covfie/core/utility/backend_traits.hpp
+++ b/lib/core/covfie/core/utility/backend_traits.hpp
@@ -1,0 +1,49 @@
+/*
+ * This file is part of covfie, a part of the ACTS project
+ *
+ * Copyright (c) 2023 CERN
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+namespace covfie::utility {
+template <typename B, std::size_t N, bool = B::is_initial>
+struct nth_backend {
+    using type = typename nth_backend<typename B::backend_t, N - 1>::type;
+};
+
+template <typename B>
+struct nth_backend<B, 0, false> {
+    using type = B;
+};
+
+template <typename B>
+struct nth_backend<B, 0, true> {
+    using type = B;
+};
+
+template <typename B, std::size_t N>
+struct nth_backend<B, N, true> {
+};
+
+template <typename B, bool = B::is_initial>
+struct backend_depth {
+};
+
+template <typename B>
+struct backend_depth<B, true> {
+    static constexpr std::size_t value = 1;
+};
+
+template <typename B>
+struct backend_depth<B, false> {
+    static constexpr std::size_t value =
+        backend_depth<typename B::backend_t>::value + 1;
+};
+}


### PR DESCRIPTION
This commit adds the `make_parameter_pack_for` functions which helps reduce the amount of boilerplate code when configuring vector fields. Unfortunately, this code is auto-generated because of a problem with the C++ language.