### PR TITLE
Remove magic headers in config-less backends

### DIFF
--- a/lib/core/covfie/core/backend/transformer/dereference.hpp
+++ b/lib/core/covfie/core/backend/transformer/dereference.hpp
@@ -70,22 +70,14 @@ struct dereference {
 
         static owning_data_t read_binary(std::istream & fs)
         {
-            utility::read_io_header(fs, IO_MAGIC_HEADER);
-
             auto be = decltype(m_backend)::read_binary(fs);
-
-            utility::read_io_footer(fs, IO_MAGIC_HEADER);
 
             return owning_data_t(configuration_t{}, std::move(be));
         }
 
         static void write_binary(std::ostream & fs, const owning_data_t & o)
         {
-            utility::write_io_header(fs, IO_MAGIC_HEADER);
-
             decltype(m_backend)::write_binary(fs, o);
-
-            utility::write_io_footer(fs, IO_MAGIC_HEADER);
         }
 
         typename backend_t::owning_data_t m_backend;

--- a/lib/core/covfie/core/backend/transformer/linear.hpp
+++ b/lib/core/covfie/core/backend/transformer/linear.hpp
@@ -112,22 +112,14 @@ struct linear {
 
         static owning_data_t read_binary(std::istream & fs)
         {
-            utility::read_io_header(fs, IO_MAGIC_HEADER);
-
             auto be = decltype(m_backend)::read_binary(fs);
-
-            utility::read_io_footer(fs, IO_MAGIC_HEADER);
 
             return owning_data_t(configuration_t{}, std::move(be));
         }
 
         static void write_binary(std::ostream & fs, const owning_data_t & o)
         {
-            utility::write_io_header(fs, IO_MAGIC_HEADER);
-
             decltype(m_backend)::write_binary(fs, o.m_backend);
-
-            utility::write_io_footer(fs, IO_MAGIC_HEADER);
         }
 
         typename backend_t::owning_data_t m_backend;

--- a/lib/core/covfie/core/backend/transformer/nearest_neighbour.hpp
+++ b/lib/core/covfie/core/backend/transformer/nearest_neighbour.hpp
@@ -107,22 +107,14 @@ struct nearest_neighbour {
 
         static owning_data_t read_binary(std::istream & fs)
         {
-            utility::read_io_header(fs, IO_MAGIC_HEADER);
-
             auto be = backend_t::owning_data_t::read_binary(fs);
-
-            utility::read_io_footer(fs, IO_MAGIC_HEADER);
 
             return owning_data_t(configuration_t{}, std::move(be));
         }
 
         static void write_binary(std::ostream & fs, const owning_data_t & o)
         {
-            utility::write_io_header(fs, IO_MAGIC_HEADER);
-
             backend_t::owning_data_t::write_binary(fs, o.m_backend);
-
-            utility::write_io_footer(fs, IO_MAGIC_HEADER);
         }
 
         typename backend_t::owning_data_t m_backend;

--- a/lib/core/covfie/core/backend/transformer/shuffle.hpp
+++ b/lib/core/covfie/core/backend/transformer/shuffle.hpp
@@ -69,22 +69,14 @@ struct shuffle {
 
         static owning_data_t read_binary(std::istream & fs)
         {
-            utility::read_io_header(fs, IO_MAGIC_HEADER);
-
             auto be = backend_t::owning_data_t::read_binary(fs);
-
-            utility::read_io_footer(fs, IO_MAGIC_HEADER);
 
             return owning_data_t(configuration_t{}, std::move(be));
         }
 
         static void write_binary(std::ostream & fs, const owning_data_t & o)
         {
-            utility::write_io_header(fs, IO_MAGIC_HEADER);
-
             backend_t::owning_data_t::write_binary(fs, o.m_backend);
-
-            utility::write_io_footer(fs, IO_MAGIC_HEADER);
         }
 
         typename backend_t::owning_data_t m_backend;


### PR DESCRIPTION
Previously, magic numbers were written to binary files even for backends which don't have any kind of data at all, such as interpolators. Since this cannot lead to data loss, this is overly restrictive. This commit removes those magic numbers to enable more permissive conversion.