### PR TITLE
Fix SFINAE bug in gcc 11

### DIFF
--- a/lib/core/covfie/core/utility/backend_traits.hpp
+++ b/lib/core/covfie/core/utility/backend_traits.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <cstddef>
+#include <variant>
 
 namespace covfie::utility {
 template <typename B, std::size_t N, bool = B::is_initial>
@@ -30,6 +31,7 @@ struct nth_backend<B, 0, true> {
 
 template <typename B, std::size_t N>
 struct nth_backend<B, N, true> {
+    using type = std::monostate;
 };
 
 template <typename B, bool = B::is_initial>


### PR DESCRIPTION
Versions of gcc were incorrectly reporting errors in the `nth_backend` helper function, even though it is (as far as I can tell) correctly defined. This commit adds some failsafes.