### PR TITLE
Find CUDA dependencies in installed CMake configs

### DIFF
--- a/cmake/covfieConfig.cmake.in
+++ b/cmake/covfieConfig.cmake.in
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022 CERN
+# Copyright (c) 2022-2024 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -14,6 +14,10 @@ set(COVFIE_PLATFORM_CPU @COVFIE_PLATFORM_CPU@)
 set(COVFIE_PLATFORM_CUDA @COVFIE_PLATFORM_CUDA@)
 set(COVFIE_REQUIRE_CXX20 @COVFIE_REQUIRE_CXX20@)
 set(COVFIE_QUIET @COVFIE_QUIET@)
+
+if(@COVFIE_PLATFORM_CUDA@)
+    find_dependency(CUDAToolkit REQUIRED)
+endif()
 
 include(
     "${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake"


### PR DESCRIPTION
As it stands, an installed version of covfie with the CUDA plugin available will correctly try to link against the CUDA runtime in a dependent project, but it won't actually look for it. This means that, if the order of operations happens to be such that covfie is loaded before CUDA, a configuration error will be thrown. This commit ensures that the installed CMake configuration looks for the CUDA runtime.