### PR TITLE
Add missing constructor to CUDA array

### DIFF
--- a/lib/cuda/covfie/cuda/backend/primitive/cuda_device_array.hpp
+++ b/lib/cuda/covfie/cuda/backend/primitive/cuda_device_array.hpp
@@ -76,6 +76,11 @@ struct cuda_device_array {
             }
         }
 
+        explicit owning_data_t(parameter_pack<owning_data_t> && args)
+            : owning_data_t(std::move(args.x))
+        {
+        }
+
         explicit owning_data_t(parameter_pack<configuration_t> && args)
             : m_size(args.x[0])
             , m_ptr(utility::cuda::device_allocate<vector_t[]>(m_size))


### PR DESCRIPTION
This fixes a concept mismatch, stemming from the time that concepts were not supported in CUDA.