### PR TITLE
Remove `CONSTRAINT` macro

### DIFF
--- a/lib/core/covfie/core/backend/primitive/array.hpp
+++ b/lib/core/covfie/core/backend/primitive/array.hpp
@@ -25,7 +25,7 @@
 
 namespace covfie::backend {
 template <
-    CONSTRAINT(concepts::vector_descriptor) _output_vector_t,
+    concepts::vector_descriptor _output_vector_t,
     typename _index_t = std::size_t>
 struct array {
     using this_t = array<_output_vector_t, _index_t>;

--- a/lib/core/covfie/core/backend/primitive/constant.hpp
+++ b/lib/core/covfie/core/backend/primitive/constant.hpp
@@ -21,8 +21,8 @@
 
 namespace covfie::backend {
 template <
-    CONSTRAINT(concepts::vector_descriptor) _input_vector_t,
-    CONSTRAINT(concepts::vector_descriptor) _output_vector_t>
+    concepts::vector_descriptor _input_vector_t,
+    concepts::vector_descriptor _output_vector_t>
 struct constant {
     using this_t = constant<_input_vector_t, _output_vector_t>;
     static constexpr bool is_initial = true;

--- a/lib/core/covfie/core/backend/primitive/identity.hpp
+++ b/lib/core/covfie/core/backend/primitive/identity.hpp
@@ -20,7 +20,7 @@
 #include <covfie/core/vector.hpp>
 
 namespace covfie::backend {
-template <CONSTRAINT(concepts::vector_descriptor) _vector_t>
+template <concepts::vector_descriptor _vector_t>
 struct identity {
     using this_t = identity<_vector_t>;
     static constexpr bool is_initial = true;

--- a/lib/core/covfie/core/backend/transformer/affine.hpp
+++ b/lib/core/covfie/core/backend/transformer/affine.hpp
@@ -21,7 +21,7 @@
 #include <covfie/core/utility/binary_io.hpp>
 
 namespace covfie::backend {
-template <CONSTRAINT(concepts::field_backend) _backend_t>
+template <concepts::field_backend _backend_t>
 struct affine {
     using this_t = affine<_backend_t>;
     static constexpr bool is_initial = false;

--- a/lib/core/covfie/core/backend/transformer/backup.hpp
+++ b/lib/core/covfie/core/backend/transformer/backup.hpp
@@ -22,7 +22,7 @@
 #include <covfie/core/vector.hpp>
 
 namespace covfie::backend {
-template <CONSTRAINT(concepts::field_backend) _backend_t>
+template <concepts::field_backend _backend_t>
 struct backup {
     using this_t = backup<_backend_t>;
     static constexpr bool is_initial = false;

--- a/lib/core/covfie/core/backend/transformer/clamp.hpp
+++ b/lib/core/covfie/core/backend/transformer/clamp.hpp
@@ -23,7 +23,7 @@
 #include <covfie/core/vector.hpp>
 
 namespace covfie::backend {
-template <CONSTRAINT(concepts::field_backend) _backend_t>
+template <concepts::field_backend _backend_t>
 struct clamp {
     using this_t = clamp<_backend_t>;
     static constexpr bool is_initial = false;

--- a/lib/core/covfie/core/backend/transformer/dereference.hpp
+++ b/lib/core/covfie/core/backend/transformer/dereference.hpp
@@ -21,7 +21,7 @@
 #include <covfie/core/vector.hpp>
 
 namespace covfie::backend {
-template <CONSTRAINT(concepts::field_backend) _backend_t>
+template <concepts::field_backend _backend_t>
 struct dereference {
     using this_t = dereference<_backend_t>;
     static constexpr bool is_initial = false;

--- a/lib/core/covfie/core/backend/transformer/hilbert.hpp
+++ b/lib/core/covfie/core/backend/transformer/hilbert.hpp
@@ -30,8 +30,8 @@
 
 namespace covfie::backend {
 template <
-    CONSTRAINT(concepts::vector_descriptor) _input_vector_t,
-    CONSTRAINT(concepts::field_backend) _storage_t>
+    concepts::vector_descriptor _input_vector_t,
+    concepts::field_backend _storage_t>
 struct hilbert {
     using this_t = hilbert<_input_vector_t, _storage_t>;
     static constexpr bool is_initial = false;

--- a/lib/core/covfie/core/backend/transformer/linear.hpp
+++ b/lib/core/covfie/core/backend/transformer/linear.hpp
@@ -25,8 +25,8 @@
 
 namespace covfie::backend {
 template <
-    CONSTRAINT(concepts::field_backend) _backend_t,
-    CONSTRAINT(concepts::vector_descriptor) _input_vector_d = covfie::vector::
+    concepts::field_backend _backend_t,
+    concepts::vector_descriptor _input_vector_d = covfie::vector::
         vector_d<float, _backend_t::contravariant_input_t::dimensions>>
 struct linear {
     using this_t = linear<_backend_t, _input_vector_d>;

--- a/lib/core/covfie/core/backend/transformer/morton.hpp
+++ b/lib/core/covfie/core/backend/transformer/morton.hpp
@@ -81,8 +81,8 @@ struct morton_pdep_mask {
 #endif
 
 template <
-    CONSTRAINT(concepts::vector_descriptor) _input_vector_t,
-    CONSTRAINT(concepts::field_backend) _storage_t,
+    concepts::vector_descriptor _input_vector_t,
+    concepts::field_backend _storage_t,
     bool use_bmi2 = true>
 struct morton {
     using this_t = morton<_input_vector_t, _storage_t>;

--- a/lib/core/covfie/core/backend/transformer/nearest_neighbour.hpp
+++ b/lib/core/covfie/core/backend/transformer/nearest_neighbour.hpp
@@ -25,8 +25,8 @@
 
 namespace covfie::backend {
 template <
-    CONSTRAINT(concepts::field_backend) _backend_t,
-    CONSTRAINT(concepts::vector_descriptor) _input_vector_d = covfie::vector::
+    concepts::field_backend _backend_t,
+    concepts::vector_descriptor _input_vector_d = covfie::vector::
         vector_d<float, _backend_t::contravariant_input_t::dimensions>>
 struct nearest_neighbour {
     using this_t = nearest_neighbour<_backend_t, _input_vector_d>;

--- a/lib/core/covfie/core/backend/transformer/shuffle.hpp
+++ b/lib/core/covfie/core/backend/transformer/shuffle.hpp
@@ -20,7 +20,7 @@
 #include <covfie/core/utility/binary_io.hpp>
 
 namespace covfie::backend {
-template <CONSTRAINT(concepts::field_backend) _backend_t, typename _shuffle>
+template <concepts::field_backend _backend_t, typename _shuffle>
 struct shuffle {
     using this_t = shuffle<_backend_t, _shuffle>;
     static constexpr bool is_initial = false;

--- a/lib/core/covfie/core/backend/transformer/strided.hpp
+++ b/lib/core/covfie/core/backend/transformer/strided.hpp
@@ -27,8 +27,8 @@
 
 namespace covfie::backend {
 template <
-    CONSTRAINT(concepts::vector_descriptor) _input_vector_t,
-    CONSTRAINT(concepts::field_backend) _storage_t>
+    concepts::vector_descriptor _input_vector_t,
+    concepts::field_backend _storage_t>
 struct strided {
     using this_t = strided<_input_vector_t, _storage_t>;
     static constexpr bool is_initial = false;

--- a/lib/core/covfie/core/definitions.hpp
+++ b/lib/core/covfie/core/definitions.hpp
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#define CONSTRAINT(x) x
-
 #ifdef _MSC_VER
 #define UNLIKELY(x) x
 #else

--- a/lib/core/covfie/core/field.hpp
+++ b/lib/core/covfie/core/field.hpp
@@ -18,7 +18,7 @@
 #include <covfie/core/utility/binary_io.hpp>
 
 namespace covfie {
-template <CONSTRAINT(concepts::field_backend) _backend_t>
+template <concepts::field_backend _backend_t>
 class field
 {
 public:
@@ -34,13 +34,13 @@ public:
     field(const field &) = default;
     field(field &&) = default;
 
-    template <CONSTRAINT(concepts::field_backend) other_backend>
+    template <concepts::field_backend other_backend>
     explicit field(field<other_backend> && other)
         : m_backend(std::move(other.m_backend))
     {
     }
 
-    template <CONSTRAINT(concepts::field_backend) other_backend>
+    template <concepts::field_backend other_backend>
     explicit field(const field<other_backend> & other)
         : m_backend(other.m_backend)
     {
@@ -80,7 +80,7 @@ private:
 
     friend class field_view<_backend_t>;
 
-    template <CONSTRAINT(concepts::field_backend) other_backend>
+    template <concepts::field_backend other_backend>
     friend class field;
 };
 }

--- a/lib/core/covfie/core/field_view.hpp
+++ b/lib/core/covfie/core/field_view.hpp
@@ -16,10 +16,10 @@
 #include <covfie/core/qualifiers.hpp>
 
 namespace covfie {
-template <CONSTRAINT(concepts::field_backend) _backend>
+template <concepts::field_backend _backend>
 class field;
 
-template <CONSTRAINT(concepts::field_backend) _backend_tc>
+template <concepts::field_backend _backend_tc>
 class field_view
 {
 public:

--- a/lib/cpu/covfie/cpu/backend/primitive/c_array.hpp
+++ b/lib/cpu/covfie/cpu/backend/primitive/c_array.hpp
@@ -16,7 +16,7 @@
 
 namespace covfie::backend {
 template <
-    CONSTRAINT(concepts::vector_descriptor) _output_vector_t,
+    concepts::vector_descriptor _output_vector_t,
     typename _index_t = std::size_t>
 using c_array = array<_output_vector_t, _index_t>;
 }

--- a/lib/cuda/covfie/cuda/backend/primitive/cuda_device_array.hpp
+++ b/lib/cuda/covfie/cuda/backend/primitive/cuda_device_array.hpp
@@ -24,7 +24,7 @@
 
 namespace covfie::backend {
 template <
-    CONSTRAINT(concepts::vector_descriptor) _output_vector_t,
+    concepts::vector_descriptor _output_vector_t,
     typename _index_t = std::size_t>
 struct cuda_device_array {
     using this_t = cuda_device_array<_output_vector_t, _index_t>;

--- a/lib/cuda/covfie/cuda/backend/primitive/cuda_texture.hpp
+++ b/lib/cuda/covfie/cuda/backend/primitive/cuda_texture.hpp
@@ -31,8 +31,8 @@ enum class cuda_texture_interpolation {
 };
 
 template <
-    CONSTRAINT(concepts::vector_descriptor) _input_vector_t,
-    CONSTRAINT(concepts::vector_descriptor) _output_vector_t,
+    concepts::vector_descriptor _input_vector_t,
+    concepts::vector_descriptor _output_vector_t,
     cuda_texture_interpolation _interpolation_method =
         cuda_texture_interpolation::LINEAR>
 struct cuda_texture {


### PR DESCRIPTION
This macro is no longer necessary now that we have C++20 enabled as the minimum C++ standard.