### PR TITLE
Add covariant casting transformer

### DIFF
--- a/lib/core/covfie/core/backend/transformer/covariant_cast.hpp
+++ b/lib/core/covfie/core/backend/transformer/covariant_cast.hpp
@@ -1,0 +1,136 @@
+/*
+ * This file is part of covfie, a part of the ACTS project
+ *
+ * Copyright (c) 2022-2024 CERN
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <iostream>
+#include <variant>
+
+#include <covfie/core/concepts.hpp>
+#include <covfie/core/definitions.hpp>
+#include <covfie/core/parameter_pack.hpp>
+#include <covfie/core/qualifiers.hpp>
+#include <covfie/core/utility/binary_io.hpp>
+#include <covfie/core/vector.hpp>
+
+namespace covfie::backend {
+template <typename target_type, concepts::field_backend _backend_t>
+struct covariant_cast {
+    using this_t = covariant_cast<target_type, _backend_t>;
+    static constexpr bool is_initial = false;
+
+    using backend_t = _backend_t;
+
+    using contravariant_input_t = typename backend_t::contravariant_input_t;
+    using covariant_output_t = vector::array_vector_d<vector::vector_d<
+        target_type,
+        backend_t::covariant_output_t::dimensions>>;
+
+    using configuration_t = std::monostate;
+
+    static constexpr uint32_t IO_MAGIC_HEADER = 0xAB020008;
+
+    struct owning_data_t {
+        using parent_t = this_t;
+
+        owning_data_t() = default;
+
+        template <typename... Args>
+        explicit owning_data_t(configuration_t, Args... args)
+            : m_backend(std::forward<Args>(args)...)
+        {
+        }
+
+        explicit owning_data_t(parameter_pack<owning_data_t> && conf)
+            : owning_data_t(std::move(conf.x))
+        {
+        }
+
+        template <typename... Args>
+        explicit owning_data_t(parameter_pack<configuration_t, Args...> && args)
+            : m_backend(std::move(args.xs))
+        {
+        }
+
+        explicit owning_data_t(
+            const configuration_t &, typename backend_t::owning_data_t && b
+        )
+            : m_backend(b)
+        {
+        }
+
+        typename backend_t::owning_data_t & get_backend(void)
+        {
+            return m_backend;
+        }
+
+        const typename backend_t::owning_data_t & get_backend(void) const
+        {
+            return m_backend;
+        }
+
+        configuration_t get_configuration(void) const
+        {
+            return {};
+        }
+
+        static owning_data_t read_binary(std::istream & fs)
+        {
+            auto be = decltype(m_backend)::read_binary(fs);
+
+            return owning_data_t(configuration_t{}, std::move(be));
+        }
+
+        static void write_binary(std::ostream & fs, const owning_data_t & o)
+        {
+            decltype(m_backend)::write_binary(fs, o);
+        }
+
+        typename backend_t::owning_data_t m_backend;
+    };
+
+    struct non_owning_data_t {
+        using parent_t = this_t;
+
+        non_owning_data_t(const owning_data_t & src)
+            : m_backend(src.m_backend)
+        {
+        }
+
+        template <std::size_t... Is>
+        COVFIE_DEVICE typename covariant_output_t::vector_t
+        at_helper(typename contravariant_input_t::vector_t c, std::index_sequence<Is...>)
+            const
+        {
+            return {static_cast<target_type>(m_backend.at(c)[Is])...};
+        }
+
+        COVFIE_DEVICE typename covariant_output_t::vector_t
+        at(typename contravariant_input_t::vector_t c) const
+        {
+            return at_helper(
+                c, std::make_index_sequence<contravariant_input_t::dimensions>{}
+            );
+        }
+
+        typename backend_t::non_owning_data_t & get_backend(void)
+        {
+            return m_backend;
+        }
+
+        const typename backend_t::non_owning_data_t & get_backend(void) const
+        {
+            return m_backend;
+        }
+
+        typename backend_t::non_owning_data_t m_backend;
+    };
+};
+}

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(
     test_build.cpp
     test_canonical.cpp
     test_atlas_like_io.cpp
+    test_covariant_cast.cpp
 )
 
 # Ensure that the tests are linked against the required libraries.

--- a/tests/core/test_covariant_cast.cpp
+++ b/tests/core/test_covariant_cast.cpp
@@ -1,0 +1,79 @@
+/*
+ * This file is part of covfie, a part of the ACTS project
+ *
+ * Copyright (c) 2022 CERN
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <cmath>
+#include <cstddef>
+
+#include <gtest/gtest.h>
+
+#include <covfie/core/backend/primitive/identity.hpp>
+#include <covfie/core/backend/transformer/covariant_cast.hpp>
+#include <covfie/core/backend/transformer/linear.hpp>
+#include <covfie/core/field.hpp>
+
+TEST(TestCovariantCast, Identity1D)
+{
+    using field_t = covfie::field<covfie::backend::covariant_cast<
+        float,
+        covfie::backend::identity<covfie::vector::int1>>>;
+
+    field_t f(covfie::make_parameter_pack(
+        field_t::backend_t::configuration_t({}),
+        field_t::backend_t::backend_t::configuration_t({})
+    ));
+    field_t::view_t fv(f);
+
+    for (int x = -10; x < 10; x++) {
+        EXPECT_EQ(fv.at(x)[0], x);
+    }
+}
+
+TEST(TestCovariantCast, Identity2D)
+{
+    using field_t = covfie::field<covfie::backend::covariant_cast<
+        float,
+        covfie::backend::identity<covfie::vector::int2>>>;
+
+    field_t f(covfie::make_parameter_pack(
+        field_t::backend_t::configuration_t({}),
+        field_t::backend_t::backend_t::configuration_t({})
+    ));
+    field_t::view_t fv(f);
+
+    for (int x = -5; x < 5; x++) {
+        for (int y = -5; y < 5; y++) {
+            EXPECT_EQ(fv.at(x, y)[0], x);
+            EXPECT_EQ(fv.at(x, y)[1], y);
+        }
+    }
+}
+
+TEST(TestCovariantCast, Identity3D)
+{
+    using field_t = covfie::field<covfie::backend::covariant_cast<
+        float,
+        covfie::backend::identity<covfie::vector::int3>>>;
+
+    field_t f(covfie::make_parameter_pack(
+        field_t::backend_t::configuration_t({}),
+        field_t::backend_t::backend_t::configuration_t({})
+    ));
+    field_t::view_t fv(f);
+
+    for (int x = -2; x < 2; x++) {
+        for (int y = -2; y < 2; y++) {
+            for (int z = -2; z < 2; z++) {
+                EXPECT_EQ(fv.at(x, y, z)[0], x);
+                EXPECT_EQ(fv.at(x, y, z)[1], y);
+                EXPECT_EQ(fv.at(x, y, z)[2], z);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The idea here is to allow the user to convert a $T \to U^n$ backend into a $T \to V^n$ by specifying a target $U \to V$ cast.