### PR TITLE
Deduplicate clang-format options

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,14 +17,13 @@ BraceWrapping:
   AfterClass: true
   AfterControlStatement: MultiLine
   AfterFunction: true
-PointerAlignment: Left
+PointerAlignment: Middle
 BinPackParameters: false
 BinPackArguments: false
 EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: Always
 FixNamespaceComments: false
 PackConstructorInitializers: Never
-PointerAlignment: Middle
 IndentWidth: 4
 ColumnLimit: 80
 IncludeBlocks: Regroup


### PR DESCRIPTION
Apparently, modern versions of clang-format complain about double definitions of options, so we should get rid of those.