### PR TITLE
Update render executables to use right unit

### DIFF
--- a/examples/cpu/render_slice.cpp
+++ b/examples/cpu/render_slice.cpp
@@ -157,10 +157,14 @@ int main(int argc, char ** argv)
 
             img[vm["height"].as<unsigned int>() * x + y] =
                 static_cast<char>(std::lround(
-                    255.f *
-                    std::min(
-                        std::sqrt(p[0] * p[0] + p[1] * p[1] + p[2] * p[2]), 1.0f
-                    )
+                    255.f * std::min(
+                                std::sqrt(
+                                    std::pow(p[0] / 0.000299792458f, 2.f) +
+                                    std::pow(p[1] / 0.000299792458f, 2.f) +
+                                    std::pow(p[2] / 0.000299792458f, 2.f)
+                                ),
+                                1.0f
+                            )
                 ));
         }
     }

--- a/examples/cuda/render_slice.cu
+++ b/examples/cuda/render_slice.cu
@@ -96,8 +96,14 @@ __global__ void render(
         typename field_t::output_t p =
             vf.at(fx * 20000.f - 10000.f, fy * 20000.f - 10000.f, z);
         out[height * x + y] = static_cast<char>(std::lround(
-            255.f *
-            std::min(std::sqrt(p[0] * p[0] + p[1] * p[1] + p[2] * p[2]), 1.0f)
+            255.f * std::min(
+                        std::sqrt(
+                            std::pow(p[0] / 0.000299792458f, 2.f) +
+                            std::pow(p[1] / 0.000299792458f, 2.f) +
+                            std::pow(p[2] / 0.000299792458f, 2.f)
+                        ),
+                        1.0f
+                    )
         ));
     }
 }

--- a/examples/cuda/render_slice_texture.cu
+++ b/examples/cuda/render_slice_texture.cu
@@ -97,8 +97,14 @@ __global__ void render(
         typename field_t::output_t p =
             vf.at(fx * 20000.f - 10000.f, fy * 20000.f - 10000.f, z);
         out[height * x + y] = static_cast<char>(std::lround(
-            255.f *
-            std::min(std::sqrt(p[0] * p[0] + p[1] * p[1] + p[2] * p[2]), 1.0f)
+            255.f * std::min(
+                        std::sqrt(
+                            std::pow(p[0] / 0.000299792458f, 2.f) +
+                            std::pow(p[1] / 0.000299792458f, 2.f) +
+                            std::pow(p[2] / 0.000299792458f, 2.f)
+                        ),
+                        1.0f
+                    )
         ));
     }
 }


### PR DESCRIPTION
In 695586b, the field conversion executables were updated to use units other than tesla, which broke the rendering executables. This commit makes the rendering executables aware of the change, allowing them to produce nice images again.