### PR TITLE
Harmonize license headers across C++ files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,11 @@ repos:
       exclude: \.(diff|patch)$
     - id: check-yaml
     - id: check-added-large-files
+
+  - repo: local
+    hooks:
+    - id: license
+      name: license
+      language: system
+      entry: ci/check_license.py
+      files: \.(cpp|hpp|ipp|cu|cuh)$

--- a/ci/check_license.py
+++ b/ci/check_license.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import sys
+from subprocess import check_output
+import re
+import difflib
+from datetime import datetime
+from fnmatch import fnmatch
+
+EXCLUDE = []
+
+
+class bcolors:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+
+
+CROSS_SYMBOL = "\u2717"
+
+
+def err(string):
+    if sys.stdout.isatty():
+        return bcolors.FAIL + bcolors.BOLD + string + bcolors.ENDC
+    else:
+        return string
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("input", nargs="+")
+    p.add_argument("--exclude", "-e", action="append", default=EXCLUDE)
+
+    args = p.parse_args()
+    extensions = ["cpp", "hpp", "ipp", "cuh", "cu", "C", "h"]
+
+    if len(args.input) == 1 and os.path.isdir(args.input[0]):
+        find_command = ["find", args.input[0]]
+        for ext in extensions:
+            find_command.extend(["-iname", f"*.{ext}", "-or"])
+        # Remove the last "-or" for a valid command
+        find_command = find_command[:-1]
+
+        srcs = (
+            str(
+                check_output(find_command),
+                "utf-8",
+            )
+            .strip()
+            .split("\n")
+        )
+        srcs = filter(lambda p: not p.startswith("./build"), srcs)
+    else:
+        srcs = args.input
+
+    raw = """/*
+ * This file is part of covfie, a part of the ACTS project
+ *
+ * Copyright (c) 2022 CERN
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/.
+ */"""
+
+    exit = 0
+    srcs = list(srcs)
+    nsrcs = len(srcs)
+    step = max(int(nsrcs / 20), 1)
+    # Iterate over all files
+    for i, src in enumerate(srcs):
+        if any([fnmatch(src, e) for e in args.exclude]):
+            continue
+
+        # Read the header
+        with open(src, "r+") as f:
+            # License could not be found in header
+            if not f.read().startswith(raw):
+                print("Invalid / missing license in " + src + "")
+                exit = 1
+                continue
+
+    sys.exit(exit)
+
+
+if "__main__" == __name__:
+    main()

--- a/examples/core/asm.cpp
+++ b/examples/core/asm.cpp
@@ -1,3 +1,13 @@
+/*
+ * This file is part of covfie, a part of the ACTS project
+ *
+ * Copyright (c) 2022 CERN
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 #include <covfie/core/algebra/affine.hpp>
 #include <covfie/core/backend/primitive/array.hpp>
 #include <covfie/core/backend/primitive/constant.hpp>

--- a/lib/core/covfie/core/algebra/vector.hpp
+++ b/lib/core/covfie/core/algebra/vector.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/backend/primitive/array.hpp
+++ b/lib/core/covfie/core/backend/primitive/array.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/backend/transformer/backup.hpp
+++ b/lib/core/covfie/core/backend/transformer/backup.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/backend/transformer/covariant_cast.hpp
+++ b/lib/core/covfie/core/backend/transformer/covariant_cast.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2024 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/backend/transformer/dereference.hpp
+++ b/lib/core/covfie/core/backend/transformer/dereference.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/backend/transformer/hilbert.hpp
+++ b/lib/core/covfie/core/backend/transformer/hilbert.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/backend/transformer/linear.hpp
+++ b/lib/core/covfie/core/backend/transformer/linear.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/backend/transformer/nearest_neighbour.hpp
+++ b/lib/core/covfie/core/backend/transformer/nearest_neighbour.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/backend/transformer/shuffle.hpp
+++ b/lib/core/covfie/core/backend/transformer/shuffle.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/backend/transformer/strided.hpp
+++ b/lib/core/covfie/core/backend/transformer/strided.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/definitions.hpp
+++ b/lib/core/covfie/core/definitions.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/field.hpp
+++ b/lib/core/covfie/core/field.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/field_view.hpp
+++ b/lib/core/covfie/core/field_view.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/parameter_pack.hpp
+++ b/lib/core/covfie/core/parameter_pack.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/utility/backend_traits.hpp
+++ b/lib/core/covfie/core/utility/backend_traits.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/utility/nd_map.hpp
+++ b/lib/core/covfie/core/utility/nd_map.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/covfie/core/vector.hpp
+++ b/lib/core/covfie/core/vector.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/tests/core/test_algebra.cpp
+++ b/tests/core/test_algebra.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/tests/core/test_atlas_like_io.cpp
+++ b/tests/core/test_atlas_like_io.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2024 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/tests/core/test_canonical.cpp
+++ b/tests/core/test_canonical.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/tests/cpu/test_cpu_array_backend.cpp
+++ b/tests/cpu/test_cpu_array_backend.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of covfie, a part of the ACTS project
  *
- * Copyright (c) 2022-2023 CERN
+ * Copyright (c) 2022 CERN
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can


### PR DESCRIPTION
This removes the year range and simply sets the copyright to 2022.