### PR TITLE
Redesign the build test CI jobs

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -52,7 +52,7 @@ jobs:
         wget https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
         tar -xzvf v1.14.0.tar.gz
         cmake -S googletest-1.14.0 -B gtest_build -DBUILD_GMOCK=Off -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/.prefixes/gtest/
-        cmake --build gtest_build
+        cmake --build gtest_build -- -j $(nproc)
         cmake --install gtest_build
     - name: Configure
       run: cmake
@@ -69,7 +69,7 @@ jobs:
         -S $GITHUB_WORKSPACE
         -B build
     - name: Build
-      run: cmake --build build
+      run: cmake --build build -- -j $(nproc)
     - name: Core tests
       run: build/tests/core/test_core
     - name: CPU tests
@@ -94,7 +94,7 @@ jobs:
 
     runs-on: "ubuntu-latest"
 
-    container: ubuntu:24.04
+    container: "nvidia/cuda:12.6.2-devel-ubuntu24.04"
 
     steps:
     - uses: actions/checkout@v3
@@ -108,13 +108,12 @@ jobs:
         libbenchmark-dev
         g++-10
         clang
-        nvidia-cuda-toolkit
     - name: Install Google Test
       run: |
         wget https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
         tar -xzvf v1.14.0.tar.gz
         cmake -S googletest-1.14.0 -B gtest_build -DBUILD_GMOCK=Off -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/.prefixes/gtest/
-        cmake --build gtest_build
+        cmake --build gtest_build -- -j $(nproc)
         cmake --install gtest_build
     - name: Configure
       run: cmake
@@ -133,60 +132,8 @@ jobs:
         -S $GITHUB_WORKSPACE
         -B build
     - name: Build
-      run: cmake --build build
+      run: cmake --build build -- -j $(nproc)
     - name: Core tests
       run: build/tests/core/test_core
-
-  windows-core:
-    strategy:
-      matrix:
-        BUILD:
-          - "Release"
-          - "Debug"
-        CXX_STANDARD:
-          - 20
-
-    name: "Windows/Core/${{ matrix.BUILD }}/MSVC/C++${{ matrix.CXX_STANDARD }}"
-
-    runs-on: "windows-latest"
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install Google Test
-      run: |
-        Invoke-WebRequest -Uri "https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz" -OutFile "gtest.tar.gz"
-        tar -xf gtest.tar.gz
-        cmake -S .\googletest-1.14.0 -B .\gtest_build -Dgtest_force_shared_crt=On -DBUILD_GMOCK=Off
-        cmake --build .\gtest_build --config ${{ matrix.BUILD }}
-        cmake --install .\gtest_build --config ${{ matrix.BUILD }} --prefix ${{ github.workspace }}\.prefix
-    - name: Install Google Benchmark
-      run: |
-        Invoke-WebRequest -Uri "https://github.com/google/benchmark/archive/refs/tags/v1.8.3.tar.gz" -OutFile "gbench.tar.gz"
-        tar -xf gbench.tar.gz
-        cmake -S .\benchmark-1.8.3 -B .\gbench_build -DCMAKE_PREFIX_PATH=${{ github.workspace }}\.prefix -DBENCHMARK_ENABLE_TESTING=Off
-        cmake --build .\gbench_build --config ${{ matrix.BUILD }}
-        cmake --install .\gbench_build --config ${{ matrix.BUILD }} --prefix ${{ github.workspace }}\.prefix
-    - name: Install Boost
-      run: |
-        Invoke-WebRequest -Uri "https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.gz" -OutFile "boost.tar.gz"
-        tar -xf boost.tar.gz
-        cd boost_1_83_0
-        .\bootstrap.bat
-        .\b2 install --with-log --with-program_options --prefix="${{ github.workspace }}\.prefix"
-    - name: Configure
-      run: cmake
-        -DCOVFIE_FAIL_ON_WARNINGS=TRUE
-        -DCOVFIE_BUILD_TESTS=On
-        -DCOVFIE_BUILD_EXAMPLES=On
-        -DCOVFIE_BUILD_BENCHMARKS=On
-        -DCOVFIE_PLATFORM_CPU=On
-        -DCOVFIE_QUIET=On
-        -DCOVFIE_TEST_HEADERS=On
-        -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }}
-        -DCMAKE_PREFIX_PATH="${{ github.workspace }}\.prefix"
-        -S ${{ github.workspace }}
-        -B build
-    - name: Build
-      run: cmake --build build --config ${{ matrix.BUILD }}
-    - name: Core tests
-      run: .\build\tests\core\${{ matrix.BUILD}}\test_core.exe
+    - name: CPU tests
+      run: build/tests/cpu/test_cpu


### PR DESCRIPTION
Enables parallelism, uses the NVIDIA Docker containers, and removes the Windows CI.