### PR TITLE
Harmonize license header in CMake files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       name: license
       language: system
       entry: ci/check_license.py
-      files: \.(cpp|hpp|ipp|cu|cuh)$
+      files: ((CMakeLists\.txt)|(\.(cpp|hpp|ipp|cu|cuh|cmake)))$
 
   - repo: https://github.com/BlankSpruce/gersemi
     rev: "0.17.0"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022-2023 CERN
+# Copyright (c) 2022 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022-2023 CERN
+# Copyright (c) 2022 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/benchmarks/cuda/CMakeLists.txt
+++ b/benchmarks/cuda/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022-2023 CERN
+# Copyright (c) 2022 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/cmake/covfie-compiler-options-cpp.cmake
+++ b/cmake/covfie-compiler-options-cpp.cmake
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2023 CERN
+# Copyright (c) 2022 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/cmake/covfie-compiler-options-cuda.cmake
+++ b/cmake/covfie-compiler-options-cuda.cmake
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2023 CERN
+# Copyright (c) 2022 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/cmake/covfie-functions.cmake
+++ b/cmake/covfie-functions.cmake
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2023 CERN
+# Copyright (c) 2022 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022-2023 CERN
+# Copyright (c) 2022 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/examples/cuda/CMakeLists.txt
+++ b/examples/cuda/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022-2023 CERN
+# Copyright (c) 2022 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022-2023 CERN
+# Copyright (c) 2022 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/cpu/CMakeLists.txt
+++ b/lib/cpu/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022-2023 CERN
+# Copyright (c) 2022 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022-2023 CERN
+# Copyright (c) 2022 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022-2023 CERN
+# Copyright (c) 2022 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2022-2023 CERN
+# Copyright (c) 2022 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can

--- a/tests/googletest/CMakeLists.txt
+++ b/tests/googletest/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of covfie, a part of the ACTS project
 #
-# Copyright (c) 2023 CERN
+# Copyright (c) 2022 CERN
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can


### PR DESCRIPTION
This commit extends the enforcement of license headers to include CMake files, as well as the existing C++ files.