### PR TITLE
Add tests for downstream builds

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,0 +1,53 @@
+# This file is part of covfie, a part of the ACTS project
+#
+# Copyright (c) 2022 CERN
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+name: Downstream Build Tests
+
+on: [ push, pull_request ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  linux-core:
+    name: "Linux"
+
+    runs-on: "ubuntu-latest"
+
+    container: ubuntu:24.04
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: apt-get update && apt-get -y install
+        libboost-filesystem-dev
+        libboost-program-options-dev
+        libboost-log-dev
+        wget
+        cmake
+        g++
+    - name: Configure covfie
+      run: cmake
+        -DCMAKE_BUILD_TYPE=${{ matrix.BUILD }}
+        -DCOVFIE_FAIL_ON_WARNINGS=TRUE
+        -DCMAKE_CXX_STANDARD=20
+        -S $GITHUB_WORKSPACE
+        -B build_covfie
+    - name: Build covfie
+      run: cmake --build build_covfie -- -j $(nproc)
+    - name: Install covfie
+      run: cmake --install build_covfie --prefix "$GITHUB_WORKSPACE/.prefixes/covfie/"
+    - name: Configure downstream
+      run: cmake
+        -DCMAKE_CXX_STANDARD=20
+        -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/.prefixes/covfie/"
+        -S $GITHUB_WORKSPACE/tests/downstream
+        -B build_downstream
+    - name: Build downstream
+      run: VERBOSE=1 cmake --build build_downstream -- -j $(nproc)

--- a/tests/downstream/CMakeLists.txt
+++ b/tests/downstream/CMakeLists.txt
@@ -1,0 +1,37 @@
+# This file is part of covfie, a part of the ACTS project
+#
+# Copyright (c) 2022 CERN
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+cmake_minimum_required(VERSION 3.18)
+
+project("covfie_downstream" VERSION 0.0.0)
+
+find_package(covfie REQUIRED)
+
+add_executable(main main.cpp)
+
+target_link_libraries(
+    main
+    covfie::core
+    covfie::cpu
+)
+
+if(TARGET core)
+    message(FATAL_ERROR "Target `core` should not exist.")
+endif()
+
+if(TARGET cpu)
+    message(FATAL_ERROR "Target `cpu` should not exist.")
+endif()
+
+if(TARGET benchmark_cpu)
+    message(FATAL_ERROR "Target `benchmark_cpu` should not exist.")
+endif()
+
+if(TARGET test_core)
+    message(FATAL_ERROR "Target `test_core` should not exist.")
+endif()

--- a/tests/downstream/main.cpp
+++ b/tests/downstream/main.cpp
@@ -1,0 +1,16 @@
+/*
+ * This file is part of covfie, a part of the ACTS project
+ *
+ * Copyright (c) 2022 CERN
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <covfie/core/field.hpp>
+
+int main(int argc, char ** argv)
+{
+    return 0;
+}


### PR DESCRIPTION
This commit adds a new CI job that tests whether covfie can be used as a dependency in a downstream project.