### PR TITLE
Fix bug in the CMake install interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ cmake_minimum_required(VERSION 3.18)
 
 project("covfie" VERSION 0.10.0)
 
+# Load some dependencies.
+include(GNUInstallDirs)
+
 # Declare options which control the parts of the code being built.
 option(COVFIE_BUILD_BENCHMARKS "Build benchmark executables.")
 option(COVFIE_BUILD_TESTS "Build test executables.")
@@ -59,7 +62,6 @@ endif()
 
 # Installation logic.
 # CMake is hell.
-include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 write_basic_package_version_file(

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -24,7 +24,11 @@ endif()
 # Logic to ensure that the core module can be installed properly.
 install(TARGETS core EXPORT ${PROJECT_NAME}Targets)
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/covfie DESTINATION include)
+install(
+    DIRECTORY
+        ${CMAKE_CURRENT_SOURCE_DIR}/covfie
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
 # Hack for people using the disgusting mal-practice of pullling in external
 # projects via "add_subdirectory"...

--- a/lib/cpu/CMakeLists.txt
+++ b/lib/cpu/CMakeLists.txt
@@ -20,7 +20,11 @@ target_compile_features(cpu INTERFACE cxx_std_20)
 # Logic to ensure that the CPU module can be installed properly.
 install(TARGETS cpu EXPORT ${PROJECT_NAME}Targets)
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/covfie DESTINATION include)
+install(
+    DIRECTORY
+        ${CMAKE_CURRENT_SOURCE_DIR}/covfie
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
 target_link_libraries(cpu INTERFACE covfie::core)
 

--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -29,7 +29,11 @@ target_link_libraries(
 # Logic to ensure that the CUDA module can be installed properly.
 install(TARGETS cuda EXPORT ${PROJECT_NAME}Targets)
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/covfie DESTINATION include)
+install(
+    DIRECTORY
+        ${CMAKE_CURRENT_SOURCE_DIR}/covfie
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
 # Hack for compatibility
 add_library(covfie::cuda ALIAS cuda)


### PR DESCRIPTION
We previously relied on `CMAKE_INSTALL_INCLUDEDIR` being set, but this is not guaranteed unless `GNUInstallDirs`. CMake, of course, was quietly swallowing this code and producing invalid installations. This commit ensures that `GNUInstallDirs` is always loaded before the install interfaces are defined, and also uses the `CMAKE_INSTALL_INCLUDEDIR` variable more consistently.