### PR TITLE
Add `covfie_` prefix to library targets

### DIFF
--- a/benchmarks/common/CMakeLists.txt
+++ b/benchmarks/common/CMakeLists.txt
@@ -10,6 +10,6 @@ add_library(benchmark test_field.cpp)
 
 target_include_directories(benchmark PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(benchmark PUBLIC core)
+target_link_libraries(benchmark PUBLIC covfie_core)
 
 target_compile_definitions(benchmark PRIVATE _CRT_SECURE_NO_WARNINGS)

--- a/benchmarks/cpu/CMakeLists.txt
+++ b/benchmarks/cpu/CMakeLists.txt
@@ -13,8 +13,8 @@ add_executable(benchmark_cpu benchmark_cpu.cpp)
 target_link_libraries(
     benchmark_cpu
     PUBLIC
-        core
-        cpu
+        covfie_core
+        covfie_cpu
         benchmark
         benchmark::benchmark
         Boost::headers

--- a/benchmarks/cuda/CMakeLists.txt
+++ b/benchmarks/cuda/CMakeLists.txt
@@ -18,8 +18,8 @@ add_executable(benchmark_cuda benchmark_cuda.cu)
 target_link_libraries(
     benchmark_cuda
     PUBLIC
-        core
-        cuda
+        covfie_core
+        covfie_cuda
         benchmark
         benchmark::benchmark
         Boost::headers

--- a/benchmarks/openmp/CMakeLists.txt
+++ b/benchmarks/openmp/CMakeLists.txt
@@ -16,8 +16,8 @@ add_executable(benchmark_openmp benchmark_openmp.cpp)
 target_link_libraries(
     benchmark_openmp
     PUBLIC
-        core
-        cpu
+        covfie_core
+        covfie_cpu
         benchmark
         OpenMP::OpenMP_CXX
         benchmark::benchmark

--- a/examples/core/CMakeLists.txt
+++ b/examples/core/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(convert_bfield convert_bfield.cpp)
 target_link_libraries(
     convert_bfield
     PRIVATE
-        core
+        covfie_core
         Boost::log
         Boost::log_setup
         Boost::program_options
@@ -24,7 +24,7 @@ add_executable(convert_bfield_csv convert_bfield_csv.cpp)
 target_link_libraries(
     convert_bfield_csv
     PRIVATE
-        core
+        covfie_core
         Boost::log
         Boost::log_setup
         Boost::program_options
@@ -33,12 +33,12 @@ target_link_libraries(
 # Add the first example that can be found in the README.
 add_executable(readme_example_1 readme_example_1.cpp)
 
-target_link_libraries(readme_example_1 PRIVATE core)
+target_link_libraries(readme_example_1 PRIVATE covfie_core)
 
 # Add the second example that can be found in the README.
 add_executable(readme_example_2 readme_example_2.cpp)
 
-target_link_libraries(readme_example_2 PRIVATE core)
+target_link_libraries(readme_example_2 PRIVATE covfie_core)
 
 # Add the an executable to create 2D slices from 3D fields.
 add_executable(slice3dto2d slice3dto2d.cpp)
@@ -46,7 +46,7 @@ add_executable(slice3dto2d slice3dto2d.cpp)
 target_link_libraries(
     slice3dto2d
     PRIVATE
-        core
+        covfie_core
         Boost::log
         Boost::log_setup
         Boost::program_options
@@ -58,18 +58,18 @@ add_executable(scaleup_bfield scaleup_bfield.cpp)
 target_link_libraries(
     scaleup_bfield
     PRIVATE
-        core
+        covfie_core
         Boost::log
         Boost::log_setup
         Boost::program_options
 )
 
 add_library(asm asm.cpp)
-target_link_libraries(asm PRIVATE core)
+target_link_libraries(asm PRIVATE covfie_core)
 
 # Some libraries which are designed to inspected by the user.
 add_library(shuffle_asm shuffle_asm.cpp)
-target_link_libraries(shuffle_asm PRIVATE core)
+target_link_libraries(shuffle_asm PRIVATE covfie_core)
 
 # Executable for generating an testable field.
 add_executable(generate_test_field generate_test_field.cpp)
@@ -77,7 +77,7 @@ add_executable(generate_test_field generate_test_field.cpp)
 target_link_libraries(
     generate_test_field
     PRIVATE
-        core
+        covfie_core
         Boost::log
         Boost::log_setup
         Boost::program_options

--- a/examples/cpu/CMakeLists.txt
+++ b/examples/cpu/CMakeLists.txt
@@ -12,8 +12,8 @@ add_executable(render_slice_cpu render_slice.cpp)
 target_link_libraries(
     render_slice_cpu
     PRIVATE
-        core
-        cpu
+        covfie_core
+        covfie_cpu
         bitmap
         Boost::log
         Boost::log_setup
@@ -25,8 +25,8 @@ add_executable(render_image_cpu render_image.cpp)
 target_link_libraries(
     render_image_cpu
     PRIVATE
-        core
-        cpu
+        covfie_core
+        covfie_cpu
         bitmap
         Boost::log
         Boost::log_setup

--- a/examples/cuda/CMakeLists.txt
+++ b/examples/cuda/CMakeLists.txt
@@ -19,8 +19,8 @@ add_executable(render_slice_cuda render_slice.cu)
 target_link_libraries(
     render_slice_cuda
     PRIVATE
-        core
-        cuda
+        covfie_core
+        covfie_cuda
         bitmap
         Boost::log
         Boost::log_setup
@@ -33,8 +33,8 @@ add_executable(render_slice_texture_cuda render_slice_texture.cu)
 target_link_libraries(
     render_slice_texture_cuda
     PRIVATE
-        core
-        cuda
+        covfie_core
+        covfie_cuda
         bitmap
         Boost::log
         Boost::log_setup

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -6,23 +6,30 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 
-add_library(core INTERFACE)
+add_library(covfie_core INTERFACE)
 
 target_include_directories(
-    core
+    covfie_core
     INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_compile_features(core INTERFACE cxx_std_20)
+target_compile_features(covfie_core INTERFACE cxx_std_20)
 
 if(COVFIE_QUIET)
-    target_compile_definitions(core INTERFACE COVFIE_QUIET)
+    target_compile_definitions(covfie_core INTERFACE COVFIE_QUIET)
 endif()
 
 # Logic to ensure that the core module can be installed properly.
-install(TARGETS core EXPORT ${PROJECT_NAME}Targets)
+set_target_properties(
+    covfie_core
+    PROPERTIES
+        EXPORT_NAME
+            core
+)
+
+install(TARGETS covfie_core EXPORT ${PROJECT_NAME}Targets)
 
 install(
     DIRECTORY
@@ -32,7 +39,9 @@ install(
 
 # Hack for people using the disgusting mal-practice of pullling in external
 # projects via "add_subdirectory"...
-add_library(covfie::core ALIAS core)
+if(NOT PROJECT_IS_TOP_LEVEL)
+    add_library(covfie::core ALIAS covfie_core)
+endif()
 
 # Test the public headers of covfie::core.
 if(COVFIE_TEST_HEADERS)
@@ -45,7 +54,7 @@ if(COVFIE_TEST_HEADERS)
     )
 
     covfie_test_public_headers(
-        core
+        covfie_core
         "${public_headers}"
     )
 endif()

--- a/lib/cpu/CMakeLists.txt
+++ b/lib/cpu/CMakeLists.txt
@@ -6,19 +6,26 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 
-add_library(cpu INTERFACE)
+add_library(covfie_cpu INTERFACE)
 
 target_include_directories(
-    cpu
+    covfie_cpu
     INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_compile_features(cpu INTERFACE cxx_std_20)
+target_compile_features(covfie_cpu INTERFACE cxx_std_20)
 
 # Logic to ensure that the CPU module can be installed properly.
-install(TARGETS cpu EXPORT ${PROJECT_NAME}Targets)
+set_target_properties(
+    covfie_cpu
+    PROPERTIES
+        EXPORT_NAME
+            cpu
+)
+
+install(TARGETS covfie_cpu EXPORT ${PROJECT_NAME}Targets)
 
 install(
     DIRECTORY
@@ -26,10 +33,12 @@ install(
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-target_link_libraries(cpu INTERFACE covfie::core)
+target_link_libraries(covfie_cpu INTERFACE covfie_core)
 
 # Hack for compatibility
-add_library(covfie::cpu ALIAS cpu)
+if(NOT PROJECT_IS_TOP_LEVEL)
+    add_library(covfie::cpu ALIAS covfie_cpu)
+endif()
 
 # Test the public headers of covfie::cpu.
 if(COVFIE_TEST_HEADERS)
@@ -42,7 +51,7 @@ if(COVFIE_TEST_HEADERS)
     )
 
     covfie_test_public_headers(
-        cpu
+        covfie_cpu
         "${public_headers}"
     )
 endif()

--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -8,26 +8,33 @@
 
 find_package(CUDAToolkit REQUIRED)
 
-add_library(cuda INTERFACE)
+add_library(covfie_cuda INTERFACE)
 
 target_include_directories(
-    cuda
+    covfie_cuda
     INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_compile_features(cuda INTERFACE cxx_std_20)
+target_compile_features(covfie_cuda INTERFACE cxx_std_20)
 
 target_link_libraries(
-    cuda
+    covfie_cuda
     INTERFACE
         CUDA::cudart
-        covfie::core
+        covfie_core
 )
 
 # Logic to ensure that the CUDA module can be installed properly.
-install(TARGETS cuda EXPORT ${PROJECT_NAME}Targets)
+set_target_properties(
+    covfie_cuda
+    PROPERTIES
+        EXPORT_NAME
+            cuda
+)
+
+install(TARGETS covfie_cuda EXPORT ${PROJECT_NAME}Targets)
 
 install(
     DIRECTORY
@@ -36,7 +43,9 @@ install(
 )
 
 # Hack for compatibility
-add_library(covfie::cuda ALIAS cuda)
+if(NOT PROJECT_IS_TOP_LEVEL)
+    add_library(covfie::cuda ALIAS covfie_cuda)
+endif()
 
 # Test the public headers of covfie::cuda.
 if(COVFIE_TEST_HEADERS)
@@ -49,7 +58,7 @@ if(COVFIE_TEST_HEADERS)
     )
 
     covfie_test_public_headers(
-        cuda
+        covfie_cuda
         "${public_headers}"
     )
 endif()

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -35,7 +35,7 @@ add_executable(
 target_link_libraries(
     test_core
     PUBLIC
-        core
+        covfie_core
         GTest::gtest
         GTest::gtest_main
         Boost::filesystem

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -13,8 +13,8 @@ add_executable(test_cpu test_cpu_array_backend.cpp)
 target_link_libraries(
     test_cpu
     PUBLIC
-        core
-        cpu
+        covfie_core
+        covfie_cpu
         GTest::gtest
         GTest::gtest_main
 )

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -19,8 +19,8 @@ add_executable(test_cuda test_cuda_array.cu)
 target_link_libraries(
     test_cuda
     PUBLIC
-        core
-        cuda
+        covfie_core
+        covfie_cuda
         GTest::gtest
         GTest::gtest_main
 )


### PR DESCRIPTION
This is to avoid name collisions with other libraries when used as a downstream project.