### PR TITLE
Enable installation only if top-level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,31 +71,33 @@ if(COVFIE_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
-# Installation logic.
-# CMake is hell.
-include(CMakePackageConfigHelpers)
+if(PROJECT_IS_TOP_LEVEL)
+    # Installation logic.
+    # CMake is hell.
+    include(CMakePackageConfigHelpers)
 
-write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion
-)
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
+    )
 
-configure_package_config_file(
-    ${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
-)
+    configure_package_config_file(
+        ${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
+    )
 
-install(
-    EXPORT ${PROJECT_NAME}Targets
-    NAMESPACE ${PROJECT_NAME}::
-    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
-)
+    install(
+        EXPORT ${PROJECT_NAME}Targets
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
+    )
 
-install(
-    FILES
-        ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-        ${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
-)
+    install(
+        FILES
+            ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+            ${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
+    )
+endif()

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -25,13 +25,15 @@ set_target_properties(
             core
 )
 
-install(TARGETS covfie_core EXPORT ${PROJECT_NAME}Targets)
+if(PROJECT_IS_TOP_LEVEL)
+    install(TARGETS covfie_core EXPORT ${PROJECT_NAME}Targets)
 
-install(
-    DIRECTORY
-        ${CMAKE_CURRENT_SOURCE_DIR}/covfie
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+    install(
+        DIRECTORY
+            ${CMAKE_CURRENT_SOURCE_DIR}/covfie
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+endif()
 
 # Hack for people using the disgusting mal-practice of pullling in external
 # projects via "add_subdirectory"...

--- a/lib/cpu/CMakeLists.txt
+++ b/lib/cpu/CMakeLists.txt
@@ -21,13 +21,15 @@ set_target_properties(
             cpu
 )
 
-install(TARGETS covfie_cpu EXPORT ${PROJECT_NAME}Targets)
+if(PROJECT_IS_TOP_LEVEL)
+    install(TARGETS covfie_cpu EXPORT ${PROJECT_NAME}Targets)
 
-install(
-    DIRECTORY
-        ${CMAKE_CURRENT_SOURCE_DIR}/covfie
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+    install(
+        DIRECTORY
+            ${CMAKE_CURRENT_SOURCE_DIR}/covfie
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+endif()
 
 target_link_libraries(covfie_cpu INTERFACE covfie_core)
 

--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -30,13 +30,15 @@ set_target_properties(
             cuda
 )
 
-install(TARGETS covfie_cuda EXPORT ${PROJECT_NAME}Targets)
+if(PROJECT_IS_TOP_LEVEL)
+    install(TARGETS covfie_cuda EXPORT ${PROJECT_NAME}Targets)
 
-install(
-    DIRECTORY
-        ${CMAKE_CURRENT_SOURCE_DIR}/covfie
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+    install(
+        DIRECTORY
+            ${CMAKE_CURRENT_SOURCE_DIR}/covfie
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+endif()
 
 # Hack for compatibility
 if(NOT PROJECT_IS_TOP_LEVEL)


### PR DESCRIPTION
I recently noticed that covfie tries to install itself even if it is not the top level project, which is obviously problematic. This commit fixes this behaviour, adding install rules only if the project is top level.