### PR TITLE
Revert "Enable installation only if top-level"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,33 +71,31 @@ if(COVFIE_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
-if(PROJECT_IS_TOP_LEVEL)
-    # Installation logic.
-    # CMake is hell.
-    include(CMakePackageConfigHelpers)
+# Installation logic.
+# CMake is hell.
+include(CMakePackageConfigHelpers)
 
-    write_basic_package_version_file(
-        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-        VERSION ${PROJECT_VERSION}
-        COMPATIBILITY SameMajorVersion
-    )
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
 
-    configure_package_config_file(
-        ${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
-        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-        INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
-    )
+configure_package_config_file(
+    ${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
+)
 
-    install(
-        EXPORT ${PROJECT_NAME}Targets
-        NAMESPACE ${PROJECT_NAME}::
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
-    )
+install(
+    EXPORT ${PROJECT_NAME}Targets
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
+)
 
-    install(
-        FILES
-            ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-            ${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
-    )
-endif()
+install(
+    FILES
+        ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+        ${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
+)

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -25,15 +25,13 @@ set_target_properties(
             core
 )
 
-if(PROJECT_IS_TOP_LEVEL)
-    install(TARGETS covfie_core EXPORT ${PROJECT_NAME}Targets)
+install(TARGETS covfie_core EXPORT ${PROJECT_NAME}Targets)
 
-    install(
-        DIRECTORY
-            ${CMAKE_CURRENT_SOURCE_DIR}/covfie
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    )
-endif()
+install(
+    DIRECTORY
+        ${CMAKE_CURRENT_SOURCE_DIR}/covfie
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
 # Hack for people using the disgusting mal-practice of pullling in external
 # projects via "add_subdirectory"...

--- a/lib/cpu/CMakeLists.txt
+++ b/lib/cpu/CMakeLists.txt
@@ -21,15 +21,13 @@ set_target_properties(
             cpu
 )
 
-if(PROJECT_IS_TOP_LEVEL)
-    install(TARGETS covfie_cpu EXPORT ${PROJECT_NAME}Targets)
+install(TARGETS covfie_cpu EXPORT ${PROJECT_NAME}Targets)
 
-    install(
-        DIRECTORY
-            ${CMAKE_CURRENT_SOURCE_DIR}/covfie
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    )
-endif()
+install(
+    DIRECTORY
+        ${CMAKE_CURRENT_SOURCE_DIR}/covfie
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
 target_link_libraries(covfie_cpu INTERFACE covfie_core)
 

--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -30,15 +30,13 @@ set_target_properties(
             cuda
 )
 
-if(PROJECT_IS_TOP_LEVEL)
-    install(TARGETS covfie_cuda EXPORT ${PROJECT_NAME}Targets)
+install(TARGETS covfie_cuda EXPORT ${PROJECT_NAME}Targets)
 
-    install(
-        DIRECTORY
-            ${CMAKE_CURRENT_SOURCE_DIR}/covfie
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    )
-endif()
+install(
+    DIRECTORY
+        ${CMAKE_CURRENT_SOURCE_DIR}/covfie
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
 # Hack for compatibility
 if(NOT PROJECT_IS_TOP_LEVEL)


### PR DESCRIPTION
This reverts commit aef0d2eeb75d536300b0fdb99d75bedbdb45238f, as it breaks CMake's silly install logic.