### PR TITLE
Remove header testing code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,6 @@ option(COVFIE_BUILD_BENCHMARKS "Build benchmark executables.")
 option(COVFIE_BUILD_TESTS "Build test executables.")
 option(COVFIE_BUILD_EXAMPLES "Build example executables.")
 
-# Declare option to enable header completeness tests.
-option(COVFIE_TEST_HEADERS "Enable header completeness tests.")
-
 # Declare options for the different platforms that we wish to support.
 option(COVFIE_PLATFORM_CPU "Enable building of CPU code." On)
 option(COVFIE_PLATFORM_CUDA "Enable building of CUDA code.")

--- a/cmake/covfie-functions.cmake
+++ b/cmake/covfie-functions.cmake
@@ -3,54 +3,6 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-# Helper function testing the covfie public headers.
-#
-# It can be used to test that public headers would include everything
-# that they need to work, and that the CMake library targets would take
-# care of declaring all of their dependencies correctly for the public
-# headers to work.
-#
-# Usage: covfie_test_public_headers( covfie_core
-#                                    include/header1.hpp ... )
-#
-function(covfie_test_public_headers library)
-    # All arguments are treated as header file names.
-    foreach(_headerName ${ARGN})
-        # Make the header filename into a "string".
-        string(REPLACE "/" "_" _headerNormName "${_headerName}")
-        string(REPLACE "." "_" _headerNormName "${_headerNormName}")
-
-        # Write a small source file that would test that the public
-        # header can be used as-is.
-        set(_testFileName
-            "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/test_${library}_${_headerNormName}.cpp"
-        )
-        if(NOT EXISTS "${_testFileName}")
-            file(
-                WRITE
-                "${_testFileName}"
-                "#include \"${_headerName}\"\n"
-                "int main() { return 0; }"
-            )
-        endif()
-
-        # Set up an executable that would build it. But hide it, don't put it
-        # into ${CMAKE_BINARY_DIR}/bin.
-        add_executable("test_${library}_${_headerNormName}" "${_testFileName}")
-        target_link_libraries(
-            "test_${library}_${_headerNormName}"
-            PRIVATE
-                ${library}
-        )
-        set_target_properties(
-            "test_${library}_${_headerNormName}"
-            PROPERTIES
-                RUNTIME_OUTPUT_DIRECTORY
-                    "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}"
-        )
-    endforeach()
-endfunction(covfie_test_public_headers)
-
 # Helper function for adding individual flags to "flag variables".
 #
 # Usage: covfie_add_flag( CMAKE_CXX_FLAGS "-Wall" )

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -38,19 +38,3 @@ install(
 if(NOT PROJECT_IS_TOP_LEVEL)
     add_library(covfie::core ALIAS covfie_core)
 endif()
-
-# Test the public headers of covfie::core.
-if(COVFIE_TEST_HEADERS)
-    include(covfie-functions)
-
-    file(
-        GLOB_RECURSE public_headers
-        RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/covfie/*.hpp"
-    )
-
-    covfie_test_public_headers(
-        covfie_core
-        "${public_headers}"
-    )
-endif()

--- a/lib/cpu/CMakeLists.txt
+++ b/lib/cpu/CMakeLists.txt
@@ -35,19 +35,3 @@ target_link_libraries(covfie_cpu INTERFACE covfie_core)
 if(NOT PROJECT_IS_TOP_LEVEL)
     add_library(covfie::cpu ALIAS covfie_cpu)
 endif()
-
-# Test the public headers of covfie::cpu.
-if(COVFIE_TEST_HEADERS)
-    include(covfie-functions)
-
-    file(
-        GLOB_RECURSE public_headers
-        RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/covfie/*.hpp"
-    )
-
-    covfie_test_public_headers(
-        covfie_cpu
-        "${public_headers}"
-    )
-endif()

--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -42,19 +42,3 @@ install(
 if(NOT PROJECT_IS_TOP_LEVEL)
     add_library(covfie::cuda ALIAS covfie_cuda)
 endif()
-
-# Test the public headers of covfie::cuda.
-if(COVFIE_TEST_HEADERS)
-    include(covfie-functions)
-
-    file(
-        GLOB_RECURSE public_headers
-        RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/covfie/*.hpp"
-    )
-
-    covfie_test_public_headers(
-        covfie_cuda
-        "${public_headers}"
-    )
-endif()


### PR DESCRIPTION
This code adds a lot of complexity to our CMake configuration but primarily requires us to know about the CUDA runtime in the main library, which I want to get rid of.