### PR TITLE
Rework platform selection CMake code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,9 @@ option(COVFIE_BUILD_TESTS "Build test executables.")
 option(COVFIE_BUILD_EXAMPLES "Build example executables.")
 
 # Declare options for the different platforms that we wish to support.
+# NOTE: These flag are only used by the example, benchmark, and test code.
 option(COVFIE_PLATFORM_CPU "Enable building of CPU code." On)
+option(COVFIE_PLATFORM_OPENMP "Enable building of OpenMP code.")
 option(COVFIE_PLATFORM_CUDA "Enable building of CUDA code.")
 
 # Additional options that may be useful in some cases, such as CI.

--- a/cmake/covfieConfig.cmake.in
+++ b/cmake/covfieConfig.cmake.in
@@ -6,13 +6,7 @@
 
 include(CMakeFindDependencyMacro)
 
-set(COVFIE_PLATFORM_CPU @COVFIE_PLATFORM_CPU@)
-set(COVFIE_PLATFORM_CUDA @COVFIE_PLATFORM_CUDA@)
 set(COVFIE_QUIET @COVFIE_QUIET@)
-
-if(@COVFIE_PLATFORM_CUDA@)
-    find_dependency(CUDAToolkit REQUIRED)
-endif()
 
 include(
     "${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake"

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -32,18 +32,3 @@ install covfie, proceed with the following commands:
     $ cmake -S covfie -B covfie_build -DCMAKE_INSTALL_PREFIX=[prefix] -DCOVFIE_PLATFORM_CPU=On -DCOVFIE_PLATFORM_CUDA=On
     $ cmake --build build
     $ cmake --install build
-
-Configuration flags
--------------------
-
-If all went according to plan, covfie is now installed! Please note that we
-only install code for platforms that the user requests. The following flags can
-be passed to CMake (through the :code:`-D[FLAG]=On` flags):
-
-:code:`COVFIE_PLATFORM_CPU`
-    Install the relevant headers for the CPU-specific parts of the library
-    (enabled by default)
-
-:code:`COVFIE_PLATFORM_CUDA`
-    Install the relevant headers for the CUDA-specific parts of the library
-    (disabled by default)

--- a/docs/user/integration.rst
+++ b/docs/user/integration.rst
@@ -42,11 +42,5 @@ The CMake setup exposes some of the flags which were used to installed covfie
 in the first place, which allows user to make certain decision based on the way
 in which covfie was installed. Variables set are as follows:
 
-:code:`COVFIE_PLATFORM_CPU`
-    True iff the CPU-specific headers were installed.
-
-:code:`COVFIE_PLATFORM_CUDA`
-    True iff the CUDA-specific headers were installed.
-
 :code:`COVFIE_QUIET`
     Silences warnings about missing compiler features.

--- a/examples/cuda/CMakeLists.txt
+++ b/examples/cuda/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(
     PRIVATE
         covfie_core
         covfie_cuda
+        CUDA::cudart
         bitmap
         Boost::log
         Boost::log_setup
@@ -31,6 +32,7 @@ target_link_libraries(
     PRIVATE
         covfie_core
         covfie_cuda
+        CUDA::cudart
         bitmap
         Boost::log
         Boost::log_setup

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -3,11 +3,5 @@
 # SPDX-License-Identifier: MPL-2.0
 
 add_subdirectory(core)
-
-if(COVFIE_PLATFORM_CPU)
-    add_subdirectory(cpu)
-endif()
-
-if(COVFIE_PLATFORM_CUDA)
-    add_subdirectory(cuda)
-endif()
+add_subdirectory(cpu)
+add_subdirectory(cuda)

--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -2,8 +2,6 @@
 # SPDX-FileCopyrightText: 2022 CERN
 # SPDX-License-Identifier: MPL-2.0
 
-find_package(CUDAToolkit REQUIRED)
-
 add_library(covfie_cuda INTERFACE)
 
 target_include_directories(
@@ -15,12 +13,7 @@ target_include_directories(
 
 target_compile_features(covfie_cuda INTERFACE cxx_std_20)
 
-target_link_libraries(
-    covfie_cuda
-    INTERFACE
-        CUDA::cudart
-        covfie_core
-)
+target_link_libraries(covfie_cuda INTERFACE covfie_core)
 
 # Logic to ensure that the CUDA module can be installed properly.
 set_target_properties(

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -5,6 +5,8 @@
 # Enable the CUDA language!
 enable_language(CUDA)
 
+find_package(CUDAToolkit REQUIRED)
+
 # Set up the CUDA compiler flags for the tests.
 include(covfie-compiler-options-cuda)
 
@@ -17,6 +19,7 @@ target_link_libraries(
     PUBLIC
         covfie_core
         covfie_cuda
+        CUDA::cudart
         GTest::gtest
         GTest::gtest_main
 )


### PR DESCRIPTION
Currently, the selected platforms determine which header files are installed, but this is not a great design; it makes the installation depend very heavily on the configuration of the project which makes little sense for a header-only library. This commit reworks this design, installing all headers regardless of the configuration. The platform variables now only impact the tests, the examples, and the benchmarks.