### PR TITLE
Remove quiet setting about C++20 features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,6 @@ option(COVFIE_PLATFORM_CPU "Enable building of CPU code." On)
 option(COVFIE_PLATFORM_OPENMP "Enable building of OpenMP code.")
 option(COVFIE_PLATFORM_CUDA "Enable building of CUDA code.")
 
-# Additional options that may be useful in some cases, such as CI.
-option(
-    COVFIE_QUIET
-    "Disable warnings about missing C++ features. Enabling this is strongly discouraged."
-)
-
 option(COVFIE_FAIL_ON_WARNINGS "Treat compiler warnings as errors.")
 
 # Make the CMake modules in the cmake/ directory visible to the project.

--- a/cmake/covfieConfig.cmake.in
+++ b/cmake/covfieConfig.cmake.in
@@ -6,8 +6,6 @@
 
 include(CMakeFindDependencyMacro)
 
-set(COVFIE_QUIET @COVFIE_QUIET@)
-
 include(
     "${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake"
 )

--- a/docs/user/integration.rst
+++ b/docs/user/integration.rst
@@ -37,10 +37,3 @@ flag to the configuration of the *downstream* project:
 .. code-block:: console
 
     $ cmake ... -DCMAKE_PREFIX_PATH=[path]
-
-The CMake setup exposes some of the flags which were used to installed covfie
-in the first place, which allows user to make certain decision based on the way
-in which covfie was installed. Variables set are as follows:
-
-:code:`COVFIE_QUIET`
-    Silences warnings about missing compiler features.

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -13,10 +13,6 @@ target_include_directories(
 
 target_compile_features(covfie_core INTERFACE cxx_std_20)
 
-if(COVFIE_QUIET)
-    target_compile_definitions(covfie_core INTERFACE COVFIE_QUIET)
-endif()
-
 # Logic to ensure that the core module can be installed properly.
 set_target_properties(
     covfie_core


### PR DESCRIPTION
We now require all C++20 features to be enabled, so the `COVFIE_QUIET` flag is no longer useful.