### PR TITLE
Remove all usage of `std::enable_if`

### DIFF
--- a/examples/core/asm.cpp
+++ b/examples/core/asm.cpp
@@ -68,8 +68,3 @@ template covfie::field_view<backend_t3>::output_t
         backend_t3::contravariant_input_t::scalar_t,
         backend_t3::contravariant_input_t::scalar_t
     ) const;
-template covfie::field_view<backend_t4>::output_t
-    covfie::field_view<backend_t4>::at<
-        backend_t4::contravariant_input_t::scalar_t>(
-        backend_t4::contravariant_input_t::scalar_t
-    ) const;

--- a/extra/parameter_pack_gen/gen_parameter_pack_code.py
+++ b/extra/parameter_pack_gen/gen_parameter_pack_code.py
@@ -4,7 +4,9 @@
 
 if __name__ == "__main__":
     for n in range(1, 11):
-        print(f"template <typename F, std::enable_if_t<utility::backend_depth<typename F::backend_t>::value == {n}, bool> = true> auto make_parameter_pack_for(")
+        print("template <typename F>")
+        print(f"requires(utility::backend_depth<typename F::backend_t>::value == {n})")
+        print("auto make_parameter_pack_for(")
         print(",".join(f"typename utility::nth_backend<typename F::backend_t, {i}>::type::configuration_t && a{i}" for i in range(n)))
         print(") { return make_parameter_pack(")
         print(",".join(f"std::forward<typename utility::nth_backend<typename F::backend_t, {i}>::type::configuration_t>(a{i})" for i in range(n)))

--- a/lib/core/covfie/core/algebra/vector.hpp
+++ b/lib/core/covfie/core/algebra/vector.hpp
@@ -36,14 +36,11 @@ struct vector : public matrix<N, 1, T, I> {
     {
     }
 
-    template <
-        typename... Args,
-        std::enable_if_t<
-            std::conjunction_v<std::is_scalar<Args>...> &&
-                std::conjunction_v<std::is_convertible<Args, T>...> &&
-                sizeof...(Args) == N,
-            bool> = true>
-    COVFIE_HOST_DEVICE vector(Args... args)
+    template <typename... Args>
+    requires(
+        (std::is_scalar_v<Args> && ...) &&
+        (std::is_convertible_v<Args, T> && ...) && sizeof...(Args) == N
+    ) COVFIE_HOST_DEVICE vector(Args... args)
         : vector(array::array<T, N>{std::forward<Args>(args)...})
     {
     }

--- a/lib/core/covfie/core/backend/transformer/affine.hpp
+++ b/lib/core/covfie/core/backend/transformer/affine.hpp
@@ -60,14 +60,10 @@ struct affine {
         {
         }
 
-        template <
-            typename T,
-            std::enable_if_t<
-                std::is_same_v<
-                    typename T::parent_t::configuration_t,
-                    configuration_t>,
-                bool> = true>
-        explicit owning_data_t(const T & o)
+        template <typename T>
+        requires(std::same_as<
+                 typename T::parent_t::configuration_t,
+                 configuration_t>) explicit owning_data_t(const T & o)
             : m_transform(o.m_transform)
             , m_backend(o.m_backend)
         {

--- a/lib/core/covfie/core/backend/transformer/backup.hpp
+++ b/lib/core/covfie/core/backend/transformer/backup.hpp
@@ -80,15 +80,12 @@ struct backup {
         {
         }
 
-        template <
-            typename... Args,
-            typename B = backend_t,
-            std::enable_if_t<
-                std::is_same_v<
-                    typename B::configuration_t,
-                    utility::nd_size<B::contravariant_input_t::dimensions>>,
-                bool> = true>
-        explicit owning_data_t(Args... args)
+        template <typename... Args>
+        requires(std::same_as<
+                 typename backend_t::configuration_t,
+                 utility::nd_size<
+                     backend_t::contravariant_input_t::
+                         dimensions>>) explicit owning_data_t(Args... args)
             : m_backend(std::forward<Args>(args)...)
         {
             m_min.fill(static_cast<typename contravariant_input_t::scalar_t>(0)

--- a/lib/core/covfie/core/backend/transformer/clamp.hpp
+++ b/lib/core/covfie/core/backend/transformer/clamp.hpp
@@ -62,15 +62,12 @@ struct clamp {
         {
         }
 
-        template <
-            typename... Args,
-            typename B = backend_t,
-            std::enable_if_t<
-                std::is_same_v<
-                    typename B::configuration_t,
-                    utility::nd_size<B::contravariant_input_t::dimensions>>,
-                bool> = true>
-        explicit owning_data_t(Args... args)
+        template <typename... Args>
+        requires(std::same_as<
+                 typename backend_t::configuration_t,
+                 utility::nd_size<
+                     backend_t::contravariant_input_t::
+                         dimensions>>) explicit owning_data_t(Args... args)
             : m_backend(std::forward<Args>(args)...)
         {
             m_min.fill(static_cast<typename contravariant_input_t::scalar_t>(0)

--- a/lib/core/covfie/core/backend/transformer/hilbert.hpp
+++ b/lib/core/covfie/core/backend/transformer/hilbert.hpp
@@ -145,22 +145,17 @@ struct hilbert {
         owning_data_t & operator=(const owning_data_t &) = default;
         owning_data_t & operator=(owning_data_t &&) = default;
 
-        template <
-            typename T,
-            typename B = backend_t,
-            std::enable_if_t<
-                std::is_same_v<
-                    typename T::parent_t::configuration_t,
-                    configuration_t>,
-                bool> = true,
-            std::enable_if_t<
-                std::is_constructible_v<
-                    typename B::owning_data_t,
-                    std::size_t,
-                    std::add_rvalue_reference_t<std::unique_ptr<std::decay_t<
-                        typename B::covariant_output_t::vector_t>[]>>>,
-                bool> = true>
-        explicit owning_data_t(const T & o)
+        template <typename T>
+        requires(std::same_as<
+                 typename T::parent_t::configuration_t,
+                 configuration_t> &&
+                     std::constructible_from<
+                         typename backend_t::owning_data_t,
+                         std::size_t,
+                         std::add_rvalue_reference_t<std::unique_ptr<std::decay_t<
+                             typename backend_t::covariant_output_t::
+                                 vector_t>[]>>>) explicit owning_data_t(const T &
+                                                                            o)
             : m_sizes(o.get_configuration())
             , m_storage(
                   utility::ipow(
@@ -174,14 +169,11 @@ struct hilbert {
         {
         }
 
-        template <
-            typename... Args,
-            typename B = backend_t,
-            std::enable_if_t<
-                !std::
-                    is_constructible_v<typename B::owning_data_t, std::size_t>,
-                bool> = true>
-        explicit owning_data_t(configuration_t conf, Args... args)
+        template <typename... Args>
+        requires(std::constructible_from<
+                 typename backend_t::owning_data_t,
+                 std::
+                     size_t>) explicit owning_data_t(configuration_t conf, Args... args)
             : m_sizes(conf)
             , m_storage(std::forward<Args>(args)...)
         {

--- a/lib/core/covfie/core/backend/transformer/linear.hpp
+++ b/lib/core/covfie/core/backend/transformer/linear.hpp
@@ -73,14 +73,10 @@ struct linear {
         {
         }
 
-        template <
-            typename T,
-            std::enable_if_t<
-                std::is_same_v<
-                    typename T::parent_t::configuration_t,
-                    configuration_t>,
-                bool> = true>
-        explicit owning_data_t(const T & o)
+        template <typename T>
+        requires(std::same_as<
+                 typename T::parent_t::configuration_t,
+                 configuration_t>) explicit owning_data_t(const T & o)
             : m_backend(o.m_backend)
         {
         }

--- a/lib/core/covfie/core/backend/transformer/morton.hpp
+++ b/lib/core/covfie/core/backend/transformer/morton.hpp
@@ -190,22 +190,17 @@ struct morton {
 
         owning_data_t() = default;
 
-        template <
-            typename T,
-            typename B = backend_t,
-            std::enable_if_t<
-                std::is_same_v<
-                    typename T::parent_t::configuration_t,
-                    configuration_t>,
-                bool> = true,
-            std::enable_if_t<
-                std::is_constructible_v<
-                    typename B::owning_data_t,
-                    std::size_t,
-                    std::add_rvalue_reference_t<std::unique_ptr<std::decay_t<
-                        typename B::covariant_output_t::vector_t>[]>>>,
-                bool> = true>
-        explicit owning_data_t(const T & o)
+        template <typename T>
+        requires(std::same_as<
+                 typename T::parent_t::configuration_t,
+                 configuration_t> &&
+                     std::constructible_from<
+                         typename backend_t::owning_data_t,
+                         std::size_t,
+                         std::add_rvalue_reference_t<std::unique_ptr<std::decay_t<
+                             typename backend_t::covariant_output_t::
+                                 vector_t>[]>>>) explicit owning_data_t(const T &
+                                                                            o)
             : m_sizes(o.get_configuration())
             , m_storage(
                   utility::ipow(
@@ -219,20 +214,19 @@ struct morton {
         {
         }
 
-        template <
-            typename... Args,
-            std::enable_if_t<(sizeof...(Args) > 0), bool> = true>
-        explicit owning_data_t(parameter_pack<configuration_t, Args...> && args)
+        template <typename... Args>
+        requires(sizeof...(Args) > 0) explicit owning_data_t(
+            parameter_pack<configuration_t, Args...> && args
+        )
             : m_sizes(args.x)
             , m_storage(std::move(args.xs))
         {
         }
 
-        template <
-            typename T,
-            std::enable_if_t<std::is_constructible_v<owning_data_t, T>, bool> =
-                true>
-        explicit owning_data_t(parameter_pack<T> && args)
+        template <typename T>
+        requires(std::constructible_from<
+                 owning_data_t,
+                 T>) explicit owning_data_t(parameter_pack<T> && args)
             : owning_data_t(args.x)
         {
         }

--- a/lib/core/covfie/core/backend/transformer/nearest_neighbour.hpp
+++ b/lib/core/covfie/core/backend/transformer/nearest_neighbour.hpp
@@ -71,15 +71,10 @@ struct nearest_neighbour {
         {
         }
 
-        template <
-            typename T,
-            typename... Args,
-            std::enable_if_t<
-                std::is_same_v<
-                    typename T::parent_t::configuration_t,
-                    std::monostate>,
-                bool> = true>
-        explicit owning_data_t(const T & o)
+        template <typename T>
+        requires(std::same_as<
+                 typename T::parent_t::configuration_t,
+                 std::monostate>) explicit owning_data_t(const T & o)
             : m_backend(o.get_backend())
         {
         }

--- a/lib/core/covfie/core/backend/transformer/strided.hpp
+++ b/lib/core/covfie/core/backend/transformer/strided.hpp
@@ -104,22 +104,17 @@ struct strided {
         owning_data_t & operator=(const owning_data_t &) = default;
         owning_data_t & operator=(owning_data_t &&) = default;
 
-        template <
-            typename T,
-            typename B = backend_t,
-            std::enable_if_t<
-                std::is_same_v<
-                    typename T::parent_t::configuration_t,
-                    configuration_t>,
-                bool> = true,
-            std::enable_if_t<
-                std::is_constructible_v<
-                    typename B::owning_data_t,
-                    std::size_t,
-                    std::add_rvalue_reference_t<std::unique_ptr<std::decay_t<
-                        typename B::covariant_output_t::vector_t>[]>>>,
-                bool> = true>
-        explicit owning_data_t(const T & o)
+        template <typename T>
+        requires(std::same_as<
+                 typename T::parent_t::configuration_t,
+                 configuration_t> &&
+                     std::constructible_from<
+                         typename backend_t::owning_data_t,
+                         std::size_t,
+                         std::add_rvalue_reference_t<std::unique_ptr<std::decay_t<
+                             typename backend_t::covariant_output_t::
+                                 vector_t>[]>>>) explicit owning_data_t(const T &
+                                                                            o)
             : m_sizes(o.get_configuration())
             , m_storage(
                   std::accumulate(
@@ -133,12 +128,10 @@ struct strided {
         {
         }
 
-        template <
-            typename B = backend_t,
-            std::enable_if_t<
-                std::is_constructible_v<typename B::owning_data_t, std::size_t>,
-                bool> = true>
         explicit owning_data_t(configuration_t conf)
+            requires(std::constructible_from<
+                     typename backend_t::owning_data_t,
+                     std::size_t>)
             : m_sizes(conf)
             , m_storage(std::accumulate(
                   std::begin(m_sizes),
@@ -149,20 +142,19 @@ struct strided {
         {
         }
 
-        template <
-            typename... Args,
-            std::enable_if_t<(sizeof...(Args) > 0), bool> = true>
-        explicit owning_data_t(parameter_pack<configuration_t, Args...> && args)
+        template <typename... Args>
+        requires(sizeof...(Args) > 0) explicit owning_data_t(
+            parameter_pack<configuration_t, Args...> && args
+        )
             : m_sizes(args.x)
             , m_storage(std::move(args.xs))
         {
         }
 
-        template <
-            typename T,
-            std::enable_if_t<std::is_constructible_v<owning_data_t, T>, bool> =
-                true>
-        explicit owning_data_t(parameter_pack<T> && args)
+        template <typename T>
+        requires(std::constructible_from<
+                 owning_data_t,
+                 T>) explicit owning_data_t(parameter_pack<T> && args)
             : owning_data_t(args.x)
         {
         }

--- a/lib/core/covfie/core/field_view.hpp
+++ b/lib/core/covfie/core/field_view.hpp
@@ -37,29 +37,16 @@ public:
         return m_storage;
     }
 
-    template <
-        typename... Args,
-        typename Q = coordinate_t,
-        std::enable_if_t<
-            std::conjunction_v<std::is_convertible<
-                Args,
-                typename backend_t::contravariant_input_t::scalar_t>...>,
-            bool> = true,
-        std::enable_if_t<
-            sizeof...(Args) == backend_t::contravariant_input_t::dimensions,
-            bool> = true,
-        std::enable_if_t<!std::is_scalar_v<Q>, bool> = true>
-    COVFIE_HOST_DEVICE output_t at(Args... c) const
+    template <typename... Args>
+    requires((std::convertible_to<Args, typename backend_t::contravariant_input_t::scalar_t> && ...) && (sizeof...(Args) == backend_t::contravariant_input_t::dimensions) && !std::is_scalar_v<coordinate_t>)
+        COVFIE_HOST_DEVICE output_t at(Args... c) const
     {
         return m_storage.at(coordinate_t{
             static_cast<typename backend_t::contravariant_input_t::scalar_t>(c
             )...});
     }
 
-    template <
-        typename T,
-        std::enable_if_t<std::is_same_v<T, coordinate_t>, bool> = true>
-    COVFIE_HOST_DEVICE output_t at(T c) const
+    COVFIE_HOST_DEVICE output_t at(const coordinate_t & c) const
     {
         return m_storage.at(c);
     }

--- a/lib/core/covfie/core/parameter_pack.hpp
+++ b/lib/core/covfie/core/parameter_pack.hpp
@@ -48,14 +48,12 @@ parameter_pack<Ts...> make_parameter_pack(Ts &&... args)
 // WARNING: These functions are automatically generated. Best not edit them
 // by hand.
 
-template <
-    typename F,
-    std::enable_if_t<
-        utility::backend_depth<typename F::backend_t>::value == 1,
-        bool> = true>
-auto make_parameter_pack_for(typename utility::nth_backend<
-                             typename F::backend_t,
-                             0>::type::configuration_t && a0)
+template <typename F>
+requires(
+    utility::backend_depth<typename F::backend_t>::value == 1
+) auto make_parameter_pack_for(typename utility::
+                                   nth_backend<typename F::backend_t, 0>::type::
+                                       configuration_t && a0)
 {
     return make_parameter_pack(
         std::forward<typename utility::nth_backend<typename F::backend_t, 0>::
@@ -63,12 +61,8 @@ auto make_parameter_pack_for(typename utility::nth_backend<
     );
 }
 
-template <
-    typename F,
-    std::enable_if_t<
-        utility::backend_depth<typename F::backend_t>::value == 2,
-        bool> = true>
-auto make_parameter_pack_for(
+template <typename F>
+requires(utility::backend_depth<typename F::backend_t>::value == 2) auto make_parameter_pack_for(
     typename utility::nth_backend<typename F::backend_t, 0>::type::
         configuration_t && a0,
     typename utility::nth_backend<typename F::backend_t, 1>::type::
@@ -83,12 +77,8 @@ auto make_parameter_pack_for(
     );
 }
 
-template <
-    typename F,
-    std::enable_if_t<
-        utility::backend_depth<typename F::backend_t>::value == 3,
-        bool> = true>
-auto make_parameter_pack_for(
+template <typename F>
+requires(utility::backend_depth<typename F::backend_t>::value == 3) auto make_parameter_pack_for(
     typename utility::nth_backend<typename F::backend_t, 0>::type::
         configuration_t && a0,
     typename utility::nth_backend<typename F::backend_t, 1>::type::
@@ -107,12 +97,8 @@ auto make_parameter_pack_for(
     );
 }
 
-template <
-    typename F,
-    std::enable_if_t<
-        utility::backend_depth<typename F::backend_t>::value == 4,
-        bool> = true>
-auto make_parameter_pack_for(
+template <typename F>
+requires(utility::backend_depth<typename F::backend_t>::value == 4) auto make_parameter_pack_for(
     typename utility::nth_backend<typename F::backend_t, 0>::type::
         configuration_t && a0,
     typename utility::nth_backend<typename F::backend_t, 1>::type::
@@ -135,12 +121,8 @@ auto make_parameter_pack_for(
     );
 }
 
-template <
-    typename F,
-    std::enable_if_t<
-        utility::backend_depth<typename F::backend_t>::value == 5,
-        bool> = true>
-auto make_parameter_pack_for(
+template <typename F>
+requires(utility::backend_depth<typename F::backend_t>::value == 5) auto make_parameter_pack_for(
     typename utility::nth_backend<typename F::backend_t, 0>::type::
         configuration_t && a0,
     typename utility::nth_backend<typename F::backend_t, 1>::type::
@@ -167,12 +149,8 @@ auto make_parameter_pack_for(
     );
 }
 
-template <
-    typename F,
-    std::enable_if_t<
-        utility::backend_depth<typename F::backend_t>::value == 6,
-        bool> = true>
-auto make_parameter_pack_for(
+template <typename F>
+requires(utility::backend_depth<typename F::backend_t>::value == 6) auto make_parameter_pack_for(
     typename utility::nth_backend<typename F::backend_t, 0>::type::
         configuration_t && a0,
     typename utility::nth_backend<typename F::backend_t, 1>::type::
@@ -203,12 +181,8 @@ auto make_parameter_pack_for(
     );
 }
 
-template <
-    typename F,
-    std::enable_if_t<
-        utility::backend_depth<typename F::backend_t>::value == 7,
-        bool> = true>
-auto make_parameter_pack_for(
+template <typename F>
+requires(utility::backend_depth<typename F::backend_t>::value == 7) auto make_parameter_pack_for(
     typename utility::nth_backend<typename F::backend_t, 0>::type::
         configuration_t && a0,
     typename utility::nth_backend<typename F::backend_t, 1>::type::
@@ -243,12 +217,8 @@ auto make_parameter_pack_for(
     );
 }
 
-template <
-    typename F,
-    std::enable_if_t<
-        utility::backend_depth<typename F::backend_t>::value == 8,
-        bool> = true>
-auto make_parameter_pack_for(
+template <typename F>
+requires(utility::backend_depth<typename F::backend_t>::value == 8) auto make_parameter_pack_for(
     typename utility::nth_backend<typename F::backend_t, 0>::type::
         configuration_t && a0,
     typename utility::nth_backend<typename F::backend_t, 1>::type::
@@ -287,12 +257,8 @@ auto make_parameter_pack_for(
     );
 }
 
-template <
-    typename F,
-    std::enable_if_t<
-        utility::backend_depth<typename F::backend_t>::value == 9,
-        bool> = true>
-auto make_parameter_pack_for(
+template <typename F>
+requires(utility::backend_depth<typename F::backend_t>::value == 9) auto make_parameter_pack_for(
     typename utility::nth_backend<typename F::backend_t, 0>::type::
         configuration_t && a0,
     typename utility::nth_backend<typename F::backend_t, 1>::type::
@@ -335,12 +301,8 @@ auto make_parameter_pack_for(
     );
 }
 
-template <
-    typename F,
-    std::enable_if_t<
-        utility::backend_depth<typename F::backend_t>::value == 10,
-        bool> = true>
-auto make_parameter_pack_for(
+template <typename F>
+requires(utility::backend_depth<typename F::backend_t>::value == 10) auto make_parameter_pack_for(
     typename utility::nth_backend<typename F::backend_t, 0>::type::
         configuration_t && a0,
     typename utility::nth_backend<typename F::backend_t, 1>::type::

--- a/lib/core/covfie/core/utility/numeric.hpp
+++ b/lib/core/covfie/core/utility/numeric.hpp
@@ -9,7 +9,7 @@
 #include <type_traits>
 
 namespace covfie::utility {
-template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+template <std::integral T>
 T round_pow2(T i)
 {
     T j = 1;
@@ -18,7 +18,7 @@ T round_pow2(T i)
     return j;
 }
 
-template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+template <std::integral T>
 T ipow(T i, T p)
 {
     T r = 1;

--- a/lib/cuda/covfie/cuda/backend/primitive/cuda_texture.hpp
+++ b/lib/cuda/covfie/cuda/backend/primitive/cuda_texture.hpp
@@ -59,17 +59,13 @@ struct cuda_texture {
         owning_data_t & operator=(const owning_data_t & o) = default;
         owning_data_t(const owning_data_t & o) = default;
 
-        template <
-            typename T,
-            std::enable_if_t<
-                std::is_unsigned_v<
-                    typename T::parent_t::contravariant_input_t::scalar_t>,
-                bool> = true,
-            std::enable_if_t<
-                T::parent_t::contravariant_input_t::dimensions ==
-                    contravariant_input_t::dimensions,
-                bool> = true>
-        owning_data_t(const T & o)
+        template <typename T>
+        requires(
+            std::unsigned_integral<
+                typename T::parent_t::contravariant_input_t::scalar_t> &&
+            (T::parent_t::contravariant_input_t::dimensions ==
+             contravariant_input_t::dimensions)
+        ) owning_data_t(const T & o)
         {
             cudaChannelFormatDesc channelDesc =
                 cudaCreateChannelDesc<channel_t>();


### PR DESCRIPTION
This commit replaces all uses of `std::enable_if` by the much more elegant `requires` keyword.