### PR TITLE
Expand git ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ install/
 *.bmp
 *.cvf
 *.covfie
+.env/
+.cache/


### PR DESCRIPTION
This commit expands the `.gitignore` file, adding the `.env` and `.cache` directories for Spack and clangd, respectively.