### PR TITLE
Allow direct conversion of CPU array to CUDA

### DIFF
--- a/lib/core/covfie/core/backend/primitive/array.hpp
+++ b/lib/core/covfie/core/backend/primitive/array.hpp
@@ -194,6 +194,19 @@ struct array {
             utility::write_io_footer(fs, IO_MAGIC_HEADER);
         }
 
+        uint64_t get_size() const
+        {
+            return m_size;
+        }
+
+        std::unique_ptr<vector_t[]> get_host_array() const
+        {
+            std::unique_ptr<vector_t[]> rv =
+                std::make_unique<vector_t[]>(m_size);
+            std::memcpy(rv.get(), m_ptr.get(), m_size * sizeof(vector_t));
+            return rv;
+        }
+
         uint64_t m_size;
         std::unique_ptr<vector_t[]> m_ptr;
     };

--- a/lib/core/covfie/core/concepts.hpp
+++ b/lib/core/covfie/core/concepts.hpp
@@ -8,6 +8,7 @@
 
 #include <concepts>
 #include <iostream>
+#include <memory>
 #include <optional>
 
 #include <covfie/core/definitions.hpp>
@@ -231,6 +232,23 @@ concept field_backend = requires
                 d.get_backend()
             } -> std::same_as<const typename T::backend_t::non_owning_data_t &>;
         };
+    };
+};
+
+template <typename T>
+concept array_1d_like_field_backend = field_backend<T> && requires
+{
+    typename T::vector_t;
+
+    requires requires(const typename T::owning_data_t & d)
+    {
+        {
+            d.get_size()
+        } -> std::unsigned_integral;
+
+        {
+            d.get_host_array()
+        } -> std::same_as<std::unique_ptr<typename T::vector_t[]>>;
     };
 };
 

--- a/lib/cuda/covfie/cuda/backend/primitive/cuda_device_array.hpp
+++ b/lib/cuda/covfie/cuda/backend/primitive/cuda_device_array.hpp
@@ -91,6 +91,14 @@ struct cuda_device_array {
         {
         }
 
+        template <typename B>
+        requires(!std::same_as<B, owning_data_t> && concepts::array_1d_like_field_backend<typename B::parent_t>) explicit owning_data_t(
+            const B & o
+        )
+            : owning_data_t(o.get_size(), o.get_host_array())
+        {
+        }
+
         configuration_t get_configuration() const
         {
             return {m_size};


### PR DESCRIPTION
This commit allows for the direct conversion of CPU arrays to CUDA arrays, which was previously possible only through some transformer like the strided backend.