### PR TITLE
Fix assignment constructor in strided array

### DIFF
--- a/lib/core/covfie/core/backend/transformer/strided.hpp
+++ b/lib/core/covfie/core/backend/transformer/strided.hpp
@@ -128,10 +128,8 @@ struct strided {
         {
         }
 
-        explicit owning_data_t(configuration_t conf)
-            requires(std::constructible_from<
-                     typename backend_t::owning_data_t,
-                     std::size_t>)
+        explicit owning_data_t(configuration_t conf
+        ) requires(std::constructible_from<typename backend_t::owning_data_t, std::size_t> && !std::constructible_from<typename backend_t::owning_data_t, utility::nd_size<1>>)
             : m_sizes(conf)
             , m_storage(std::accumulate(
                   std::begin(m_sizes),
@@ -139,6 +137,20 @@ struct strided {
                   static_cast<std::size_t>(1),
                   std::multiplies<std::size_t>()
               ))
+        {
+        }
+
+        explicit owning_data_t(configuration_t conf)
+            requires(std::constructible_from<
+                     typename backend_t::owning_data_t,
+                     utility::nd_size<1>>)
+            : m_sizes(conf)
+            , m_storage(utility::nd_size<1>{std::accumulate(
+                  std::begin(m_sizes),
+                  std::end(m_sizes),
+                  static_cast<std::size_t>(1),
+                  std::multiplies<std::size_t>()
+              )})
         {
         }
 

--- a/lib/cuda/covfie/cuda/backend/primitive/cuda_device_array.hpp
+++ b/lib/cuda/covfie/cuda/backend/primitive/cuda_device_array.hpp
@@ -73,8 +73,7 @@ struct cuda_device_array {
         }
 
         explicit owning_data_t(parameter_pack<configuration_t> && args)
-            : m_size(args.x[0])
-            , m_ptr(utility::cuda::device_allocate<vector_t[]>(m_size))
+            : owning_data_t(args.x[0], std::make_unique<vector_t[]>(m_size))
         {
         }
 


### PR DESCRIPTION
This commit fixes the assignment constructor and operator in the strided array, and fixes the CUDA device array to match this.