### PR TITLE
Refactor and expand CUDA tests

### DIFF
--- a/tests/cuda/test_cuda_array.cu
+++ b/tests/cuda/test_cuda_array.cu
@@ -120,7 +120,7 @@ using BackendsInteger1D = ::testing::Types<
     CudaArrayBackend<3, float>,
     CudaArrayBackend<3, double>>;
 TYPED_TEST_SUITE(TestCudaArray, BackendsInteger1D, NameGenerator);
-TYPED_TEST(TestCudaArray, LookUp)
+TYPED_TEST(TestCudaArray, LookUpMoveConstructed)
 {
     for (std::size_t x = 0; x < this->m_size; ++x) {
         std::decay_t<typename covfie::field<TypeParam>::output_t> o =
@@ -134,7 +134,10 @@ TYPED_TEST(TestCudaArray, LookUp)
             EXPECT_EQ(o[2], x + 2);
         }
     }
+}
 
+TYPED_TEST(TestCudaArray, LookUpCopyConstructed)
+{
     for (std::size_t x = 0; x < this->m_size; ++x) {
         std::decay_t<typename covfie::field<TypeParam>::output_t> o =
             retrieve_vector<covfie::field<TypeParam>>(
@@ -149,7 +152,10 @@ TYPED_TEST(TestCudaArray, LookUp)
             EXPECT_EQ(o[2], x + 2);
         }
     }
+}
 
+TYPED_TEST(TestCudaArray, LookUpCopyAssigned)
+{
     for (std::size_t x = 0; x < this->m_size; ++x) {
         std::decay_t<typename covfie::field<TypeParam>::output_t> o =
             retrieve_vector<covfie::field<TypeParam>>(
@@ -164,7 +170,10 @@ TYPED_TEST(TestCudaArray, LookUp)
             EXPECT_EQ(o[2], x + 2);
         }
     }
+}
 
+TYPED_TEST(TestCudaArray, LookUpMoveAssigned)
+{
     for (std::size_t x = 0; x < this->m_size; ++x) {
         std::decay_t<typename covfie::field<TypeParam>::output_t> o =
             retrieve_vector<covfie::field<TypeParam>>(

--- a/tests/cuda/test_cuda_strided_array.cu
+++ b/tests/cuda/test_cuda_strided_array.cu
@@ -96,10 +96,19 @@ protected:
         );
 
         m_field = covfie::field<B>(f);
+        m_field_copied = *m_field;
+        m_field_assigned = covfie::field<B>();
+        m_field_move_assigned = covfie::field<B>();
+        *m_field_assigned = *m_field;
+        covfie::field<B> tmp = *m_field;
+        *m_field_move_assigned = std::move(tmp);
     }
 
     covfie::array::array<std::size_t, N> m_sizes;
     std::optional<covfie::field<B>> m_field;
+    std::optional<covfie::field<B>> m_field_copied;
+    std::optional<covfie::field<B>> m_field_assigned;
+    std::optional<covfie::field<B>> m_field_move_assigned;
 };
 
 template <std::size_t N, typename T>
@@ -114,11 +123,47 @@ using Backends1D = ::testing::Types<
     CudaStridedArrayBackend<1, std::size_t>,
     CudaStridedArrayBackend<1, float>>;
 TYPED_TEST_SUITE(TestCudaStrided1D, Backends1D, NameGenerator);
-TYPED_TEST(TestCudaStrided1D, LookUp)
+TYPED_TEST(TestCudaStrided1D, LookUpMoveConstructed)
 {
     for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
         std::decay_t<typename covfie::field<TypeParam>::output_t> o =
             retrieve_vector<covfie::field<TypeParam>>(*(this->m_field), {x});
+
+        EXPECT_EQ(o[0], x);
+    }
+}
+
+TYPED_TEST(TestCudaStrided1D, LookUpCopyConstructed)
+{
+    for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
+        std::decay_t<typename covfie::field<TypeParam>::output_t> o =
+            retrieve_vector<covfie::field<TypeParam>>(
+                *(this->m_field_copied), {x}
+            );
+
+        EXPECT_EQ(o[0], x);
+    }
+}
+
+TYPED_TEST(TestCudaStrided1D, LookUpMoveAssigned)
+{
+    for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
+        std::decay_t<typename covfie::field<TypeParam>::output_t> o =
+            retrieve_vector<covfie::field<TypeParam>>(
+                *(this->m_field_move_assigned), {x}
+            );
+
+        EXPECT_EQ(o[0], x);
+    }
+}
+
+TYPED_TEST(TestCudaStrided1D, LookUpCopyAssigned)
+{
+    for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
+        std::decay_t<typename covfie::field<TypeParam>::output_t> o =
+            retrieve_vector<covfie::field<TypeParam>>(
+                *(this->m_field_assigned), {x}
+            );
 
         EXPECT_EQ(o[0], x);
     }
@@ -131,7 +176,7 @@ using Backends2D = ::testing::Types<
     CudaStridedArrayBackend<2, std::size_t>,
     CudaStridedArrayBackend<2, float>>;
 TYPED_TEST_SUITE(TestCudaStrided2D, Backends2D, NameGenerator);
-TYPED_TEST(TestCudaStrided2D, LookUp)
+TYPED_TEST(TestCudaStrided2D, LookUpMoveConstructed)
 {
     for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
         for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
@@ -146,13 +191,58 @@ TYPED_TEST(TestCudaStrided2D, LookUp)
     }
 }
 
+TYPED_TEST(TestCudaStrided2D, LookUpCopyConstructed)
+{
+    for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
+        for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
+            std::decay_t<typename covfie::field<TypeParam>::output_t> o =
+                retrieve_vector<covfie::field<TypeParam>>(
+                    *(this->m_field_copied), {x, y}
+                );
+
+            EXPECT_EQ(o[0], x);
+            EXPECT_EQ(o[1], y);
+        }
+    }
+}
+
+TYPED_TEST(TestCudaStrided2D, LookUpMoveAssigned)
+{
+    for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
+        for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
+            std::decay_t<typename covfie::field<TypeParam>::output_t> o =
+                retrieve_vector<covfie::field<TypeParam>>(
+                    *(this->m_field_move_assigned), {x, y}
+                );
+
+            EXPECT_EQ(o[0], x);
+            EXPECT_EQ(o[1], y);
+        }
+    }
+}
+
+TYPED_TEST(TestCudaStrided2D, LookUpCopyAssigned)
+{
+    for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
+        for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
+            std::decay_t<typename covfie::field<TypeParam>::output_t> o =
+                retrieve_vector<covfie::field<TypeParam>>(
+                    *(this->m_field_assigned), {x, y}
+                );
+
+            EXPECT_EQ(o[0], x);
+            EXPECT_EQ(o[1], y);
+        }
+    }
+}
+
 template <typename B>
 using TestCudaStrided3D = TestLookupGeneric<3, B>;
 using Backends3D = ::testing::Types<
     CudaStridedArrayBackend<3, std::size_t>,
     CudaStridedArrayBackend<3, float>>;
 TYPED_TEST_SUITE(TestCudaStrided3D, Backends3D, NameGenerator);
-TYPED_TEST(TestCudaStrided3D, LookUp)
+TYPED_TEST(TestCudaStrided3D, LookUpMoveConstructed)
 {
     for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
         for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
@@ -160,6 +250,60 @@ TYPED_TEST(TestCudaStrided3D, LookUp)
                 std::decay_t<typename covfie::field<TypeParam>::output_t> o =
                     retrieve_vector<covfie::field<TypeParam>>(
                         *(this->m_field), {x, y, z}
+                    );
+
+                EXPECT_EQ(o[0], x);
+                EXPECT_EQ(o[1], y);
+                EXPECT_EQ(o[2], z);
+            }
+        }
+    }
+}
+
+TYPED_TEST(TestCudaStrided3D, LookUpCopyConstructed)
+{
+    for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
+        for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
+            for (std::size_t z = 0; z < this->m_sizes[2]; ++z) {
+                std::decay_t<typename covfie::field<TypeParam>::output_t> o =
+                    retrieve_vector<covfie::field<TypeParam>>(
+                        *(this->m_field_copied), {x, y, z}
+                    );
+
+                EXPECT_EQ(o[0], x);
+                EXPECT_EQ(o[1], y);
+                EXPECT_EQ(o[2], z);
+            }
+        }
+    }
+}
+
+TYPED_TEST(TestCudaStrided3D, LookUpMoveAssigned)
+{
+    for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
+        for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
+            for (std::size_t z = 0; z < this->m_sizes[2]; ++z) {
+                std::decay_t<typename covfie::field<TypeParam>::output_t> o =
+                    retrieve_vector<covfie::field<TypeParam>>(
+                        *(this->m_field_move_assigned), {x, y, z}
+                    );
+
+                EXPECT_EQ(o[0], x);
+                EXPECT_EQ(o[1], y);
+                EXPECT_EQ(o[2], z);
+            }
+        }
+    }
+}
+
+TYPED_TEST(TestCudaStrided3D, LookUpCopyAssigned)
+{
+    for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
+        for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
+            for (std::size_t z = 0; z < this->m_sizes[2]; ++z) {
+                std::decay_t<typename covfie::field<TypeParam>::output_t> o =
+                    retrieve_vector<covfie::field<TypeParam>>(
+                        *(this->m_field_assigned), {x, y, z}
                     );
 
                 EXPECT_EQ(o[0], x);

--- a/tests/cuda/test_cuda_texture.cu
+++ b/tests/cuda/test_cuda_texture.cu
@@ -129,7 +129,7 @@ using Backends2D = ::testing::Types<covfie::backend::cuda_texture<
     covfie::vector::float2,
     covfie::vector::float3>>;
 TYPED_TEST_SUITE(TestCudaLerpBackend2D, Backends2D, NameGenerator);
-TYPED_TEST(TestCudaLerpBackend2D, LookUp)
+TYPED_TEST(TestCudaLerpBackend2D, LookUpMoveConstructed)
 {
     for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
         for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
@@ -144,7 +144,10 @@ TYPED_TEST(TestCudaLerpBackend2D, LookUp)
             EXPECT_EQ(o[2], static_cast<float>(x + y));
         }
     }
+}
 
+TYPED_TEST(TestCudaLerpBackend2D, LookUpCopyConstructed)
+{
     for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
         for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
             std::decay_t<typename covfie::field<TypeParam>::output_t> o =
@@ -158,7 +161,10 @@ TYPED_TEST(TestCudaLerpBackend2D, LookUp)
             EXPECT_EQ(o[2], static_cast<float>(x + y));
         }
     }
+}
 
+TYPED_TEST(TestCudaLerpBackend2D, LookUpCopyAssigned)
+{
     for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
         for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
             std::decay_t<typename covfie::field<TypeParam>::output_t> o =
@@ -172,7 +178,10 @@ TYPED_TEST(TestCudaLerpBackend2D, LookUp)
             EXPECT_EQ(o[2], static_cast<float>(x + y));
         }
     }
+}
 
+TYPED_TEST(TestCudaLerpBackend2D, LookUpMoveAssigned)
+{
     for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
         for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
             std::decay_t<typename covfie::field<TypeParam>::output_t> o =
@@ -188,6 +197,23 @@ TYPED_TEST(TestCudaLerpBackend2D, LookUp)
     }
 }
 
+TYPED_TEST(TestCudaLerpBackend2D, LookUpInterpolated)
+{
+    for (std::size_t x = 0; x < this->m_sizes[0] - 1; ++x) {
+        for (std::size_t y = 0; y < this->m_sizes[1] - 1; ++y) {
+            std::decay_t<typename covfie::field<TypeParam>::output_t> o =
+                retrieve_vector<covfie::field<TypeParam>>(
+                    *(this->m_field),
+                    {static_cast<float>(x) + 0.25f,
+                     static_cast<float>(y) + 0.50f}
+                );
+
+            EXPECT_EQ(o[0], static_cast<float>(x) + 0.25f);
+            EXPECT_EQ(o[1], static_cast<float>(y) + 0.50f);
+        }
+    }
+}
+
 // 3D tests
 template <typename B>
 using TestCudaLerpBackend3D = TestLookupGeneric<3, B>;
@@ -195,7 +221,7 @@ using Backends3D = ::testing::Types<covfie::backend::cuda_texture<
     covfie::vector::float3,
     covfie::vector::float3>>;
 TYPED_TEST_SUITE(TestCudaLerpBackend3D, Backends3D, NameGenerator);
-TYPED_TEST(TestCudaLerpBackend3D, LookUp)
+TYPED_TEST(TestCudaLerpBackend3D, LookUpMoveConstructed)
 {
     for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
         for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
@@ -214,7 +240,10 @@ TYPED_TEST(TestCudaLerpBackend3D, LookUp)
             }
         }
     }
+}
 
+TYPED_TEST(TestCudaLerpBackend3D, LookUpCopyConstructed)
+{
     for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
         for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
             for (std::size_t z = 0; z < this->m_sizes[2]; ++z) {
@@ -232,25 +261,10 @@ TYPED_TEST(TestCudaLerpBackend3D, LookUp)
             }
         }
     }
+}
 
-    for (std::size_t x = 0; x < this->m_sizes[0] - 1; ++x) {
-        for (std::size_t y = 0; y < this->m_sizes[1] - 1; ++y) {
-            for (std::size_t z = 0; z < this->m_sizes[2] - 1; ++z) {
-                std::decay_t<typename covfie::field<TypeParam>::output_t> o =
-                    retrieve_vector<covfie::field<TypeParam>>(
-                        *(this->m_field_copied),
-                        {static_cast<float>(x) + 0.25f,
-                         static_cast<float>(y) + 0.50f,
-                         static_cast<float>(z) + 0.75f}
-                    );
-
-                EXPECT_EQ(o[0], static_cast<float>(x) + 0.25f);
-                EXPECT_EQ(o[1], static_cast<float>(y) + 0.50f);
-                EXPECT_EQ(o[2], static_cast<float>(z) + 0.75f);
-            }
-        }
-    }
-
+TYPED_TEST(TestCudaLerpBackend3D, LookUpCopyAssigned)
+{
     for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
         for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
             for (std::size_t z = 0; z < this->m_sizes[2]; ++z) {
@@ -268,7 +282,10 @@ TYPED_TEST(TestCudaLerpBackend3D, LookUp)
             }
         }
     }
+}
 
+TYPED_TEST(TestCudaLerpBackend3D, LookUpMoveAssigned)
+{
     for (std::size_t x = 0; x < this->m_sizes[0]; ++x) {
         for (std::size_t y = 0; y < this->m_sizes[1]; ++y) {
             for (std::size_t z = 0; z < this->m_sizes[2]; ++z) {
@@ -283,6 +300,27 @@ TYPED_TEST(TestCudaLerpBackend3D, LookUp)
                 EXPECT_EQ(o[0], static_cast<float>(x));
                 EXPECT_EQ(o[1], static_cast<float>(y));
                 EXPECT_EQ(o[2], static_cast<float>(z));
+            }
+        }
+    }
+}
+
+TYPED_TEST(TestCudaLerpBackend3D, LookUpInterpolated)
+{
+    for (std::size_t x = 0; x < this->m_sizes[0] - 1; ++x) {
+        for (std::size_t y = 0; y < this->m_sizes[1] - 1; ++y) {
+            for (std::size_t z = 0; z < this->m_sizes[2] - 1; ++z) {
+                std::decay_t<typename covfie::field<TypeParam>::output_t> o =
+                    retrieve_vector<covfie::field<TypeParam>>(
+                        *(this->m_field),
+                        {static_cast<float>(x) + 0.25f,
+                         static_cast<float>(y) + 0.50f,
+                         static_cast<float>(z) + 0.75f}
+                    );
+
+                EXPECT_EQ(o[0], static_cast<float>(x) + 0.25f);
+                EXPECT_EQ(o[1], static_cast<float>(y) + 0.50f);
+                EXPECT_EQ(o[2], static_cast<float>(z) + 0.75f);
             }
         }
     }


### PR DESCRIPTION
The CUDA tests previously bunched many field types (copied, assigned, etc.) together. This commit splits up the tests so they are easier to debug. Also adds new tests for the strided array.