### PR TITLE
Explicitly set CUDA texture array pointer to null

### DIFF
--- a/lib/cuda/covfie/cuda/backend/primitive/cuda_texture.hpp
+++ b/lib/cuda/covfie/cuda/backend/primitive/cuda_texture.hpp
@@ -324,7 +324,7 @@ struct cuda_texture {
             throw std::invalid_argument("Cannot perform IO on texture memory.");
         }
 
-        cudaArray_t m_array;
+        cudaArray_t m_array = nullptr;
         std::optional<cudaTextureObject_t> m_tex;
     };
 


### PR DESCRIPTION
This commit fixes a small bug in which the array pointer in the CUDA texture backend was not properly nulled, sometimes leading to memory errors.