### PR TITLE
Implement support for CUDA streams

### DIFF
--- a/lib/cuda/covfie/cuda/backend/primitive/cuda_texture.hpp
+++ b/lib/cuda/covfie/cuda/backend/primitive/cuda_texture.hpp
@@ -289,6 +289,18 @@ struct cuda_texture {
             );
         }
 
+        // NOTE: The stream is currently ignored.
+        template <typename T>
+        requires(
+            std::unsigned_integral<
+                typename T::parent_t::contravariant_input_t::scalar_t> &&
+            (T::parent_t::contravariant_input_t::dimensions ==
+             contravariant_input_t::dimensions)
+        ) owning_data_t(const T & o, const cudaStream_t &)
+            : owning_data_t(o)
+        {
+        }
+
         template <typename T>
         owning_data_t(parameter_pack<T> && i)
             : owning_data_t(std::move(i.x))
@@ -326,6 +338,7 @@ struct cuda_texture {
 
         cudaArray_t m_array = nullptr;
         std::optional<cudaTextureObject_t> m_tex;
+        std::optional<cudaStream_t> m_stream;
     };
 
     struct non_owning_data_t {

--- a/lib/cuda/covfie/cuda/utility/copy.hpp
+++ b/lib/cuda/covfie/cuda/utility/copy.hpp
@@ -1,0 +1,62 @@
+/*
+ * SPDX-PackageName: "covfie, a part of the ACTS project"
+ * SPDX-FileCopyrightText: 2022 CERN
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <covfie/core/concepts.hpp>
+
+#include "covfie/core/parameter_pack.hpp"
+
+namespace covfie::utility::cuda {
+template <typename T, typename U>
+requires(concepts::field_backend<T> &&
+             concepts::field_backend<typename std::decay_t<U>::parent_t>)
+    typename T::owning_data_t
+    copy_backend_with_stream(U && backend, const cudaStream_t & stream)
+{
+    constexpr bool can_construct_with_stream = std::
+        constructible_from<typename T::owning_data_t, U, const cudaStream_t &>;
+
+    static_assert(
+        can_construct_with_stream ||
+        (!std::decay_t<T>::is_initial && !std::decay_t<U>::parent_t::is_initial)
+    );
+
+    if constexpr (can_construct_with_stream) {
+        return typename T::owning_data_t(std::forward<U>(backend), stream);
+    } else if constexpr (std::constructible_from<
+                             typename T::owning_data_t,
+                             decltype(backend.get_configuration()),
+                             typename T::backend_t::owning_data_t &&>)
+    {
+        return typename T::owning_data_t(
+            backend.get_configuration(),
+            copy_backend_with_stream<typename T::backend_t>(
+                backend.get_backend(), stream
+            )
+        );
+    } else {
+        return typename T::owning_data_t(make_parameter_pack(
+            backend.get_configuration(),
+            copy_backend_with_stream<typename T::backend_t>(
+                backend.get_backend(), stream
+            )
+        ));
+    }
+}
+
+template <typename T, typename U>
+requires(concepts::field_backend<typename T::backend_t> &&
+             concepts::field_backend<typename std::decay_t<U>::backend_t>) T
+    copy_field_with_stream(U && field, const cudaStream_t & stream)
+{
+    return T(
+        copy_backend_with_stream<typename T::backend_t>(field.backend(), stream)
+    );
+}
+}

--- a/lib/cuda/covfie/cuda/utility/memory.hpp
+++ b/lib/cuda/covfie/cuda/utility/memory.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include <cuda_runtime.h>
 
@@ -53,48 +54,100 @@ unique_device_ptr<T> device_allocate(std::size_t n)
 }
 
 template <typename T>
-unique_device_ptr<T[]> device_copy_h2d(const T * h)
+unique_device_ptr<T[]>
+device_copy_h2d(const T * h, std::optional<cudaStream_t> stream = std::nullopt)
 {
     unique_device_ptr<T[]> r = device_allocate<T[]>();
 
-    cudaErrorCheck(cudaMemcpy(r.get(), h, sizeof(T), cudaMemcpyHostToDevice));
+    if (stream.has_value()) {
+        cudaErrorCheck(cudaMemcpyAsync(
+            r.get(), h, sizeof(T), cudaMemcpyHostToDevice, *stream
+        ));
+        cudaErrorCheck(cudaStreamSynchronize(*stream));
+    } else {
+        cudaErrorCheck(cudaMemcpy(r.get(), h, sizeof(T), cudaMemcpyHostToDevice)
+        );
+    }
 
     return r;
 }
 
 template <typename T>
-unique_device_ptr<T[]> device_copy_h2d(const T * h, std::size_t n)
+unique_device_ptr<T[]> device_copy_h2d(
+    const T * h,
+    std::size_t n,
+    std::optional<cudaStream_t> stream = std::nullopt
+)
 {
     unique_device_ptr<T[]> r = device_allocate<T[]>(n);
 
-    cudaErrorCheck(cudaMemcpy(
-        r.get(), h, n * sizeof(std::remove_extent_t<T>), cudaMemcpyHostToDevice
-    ));
+    if (stream.has_value()) {
+        cudaErrorCheck(cudaMemcpyAsync(
+            r.get(),
+            h,
+            n * sizeof(std::remove_extent_t<T>),
+            cudaMemcpyHostToDevice,
+            *stream
+        ));
+        cudaErrorCheck(cudaStreamSynchronize(*stream));
+    } else {
+        cudaErrorCheck(cudaMemcpy(
+            r.get(),
+            h,
+            n * sizeof(std::remove_extent_t<T>),
+            cudaMemcpyHostToDevice
+        ));
+    }
 
     return r;
 }
 
 template <typename T>
-unique_device_ptr<T[]> device_copy_d2d(const T * h)
+unique_device_ptr<T[]>
+device_copy_d2d(const T * h, std::optional<cudaStream_t> stream = std::nullopt)
 {
     unique_device_ptr<T[]> r = device_allocate<T[]>();
 
-    cudaErrorCheck(cudaMemcpy(r.get(), h, sizeof(T), cudaMemcpyDeviceToDevice));
+    if (stream.has_value()) {
+        cudaErrorCheck(cudaMemcpyAsync(
+            r.get(), h, sizeof(T), cudaMemcpyDeviceToDevice, *stream
+        ));
+        cudaErrorCheck(cudaStreamSynchronize(*stream));
+    } else {
+        cudaErrorCheck(
+            cudaMemcpy(r.get(), h, sizeof(T), cudaMemcpyDeviceToDevice)
+        );
+    }
 
     return r;
 }
 
 template <typename T>
-unique_device_ptr<T[]> device_copy_d2d(const T * h, std::size_t n)
+unique_device_ptr<T[]> device_copy_d2d(
+    const T * h,
+    std::size_t n,
+    std::optional<cudaStream_t> stream = std::nullopt
+)
 {
     unique_device_ptr<T[]> r = device_allocate<T[]>(n);
 
-    cudaErrorCheck(cudaMemcpy(
-        r.get(),
-        h,
-        n * sizeof(std::remove_extent_t<T>),
-        cudaMemcpyDeviceToDevice
-    ));
+    if (stream.has_value()) {
+        cudaErrorCheck(cudaMemcpyAsync(
+            r.get(),
+            h,
+            n * sizeof(std::remove_extent_t<T>),
+            cudaMemcpyDeviceToDevice,
+            *stream
+        ));
+        cudaErrorCheck(cudaStreamSynchronize(*stream));
+    } else {
+        cudaErrorCheck(cudaMemcpy(
+            r.get(),
+            h,
+            n * sizeof(std::remove_extent_t<T>),
+            cudaMemcpyDeviceToDevice
+        ));
+    }
 
     return r;
 }


### PR DESCRIPTION
This commit adds support for constructing CUDA backends on streams. While this remains fully synchronous for now, this will later allow for the use of asynchronous code and it also provides a template of how to implement SYCL code.