### PR TITLE
Add support for SYCL arrays

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -136,3 +136,63 @@ jobs:
       run: build/tests/core/test_core
     - name: CPU tests
       run: build/tests/cpu/test_cpu
+
+  linux-sycl:
+    strategy:
+      matrix:
+        BUILD:
+          - "Release"
+          - "Debug"
+        CXX_STANDARD:
+          - 20
+        COMPILER:
+          - NAME: "icpx"
+            CXX: "icpx"
+
+    name: "Linux/SYCL/${{ matrix.BUILD }}/${{ matrix.COMPILER.NAME }}/C++${{ matrix.CXX_STANDARD }}"
+
+    runs-on: "ubuntu-latest"
+
+    container: "intel/oneapi:2025.0.2-0-devel-ubuntu24.04"
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: apt-get update && apt-get -y install
+        libboost-filesystem-dev
+        libboost-program-options-dev
+        libboost-log-dev
+        wget
+        cmake
+        libbenchmark-dev
+    - name: Install Google Test
+      run: |
+        wget https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+        tar -xzvf v1.14.0.tar.gz
+        cmake -S googletest-1.14.0 -B gtest_build -DBUILD_GMOCK=Off -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/.prefixes/gtest/
+        cmake --build gtest_build -- -j $(nproc)
+        cmake --install gtest_build
+    - name: Configure
+      run: cmake
+        -DCMAKE_CXX_COMPILER=$(which ${{ matrix.COMPILER.CXX }})
+        -DCMAKE_BUILD_TYPE=${{ matrix.BUILD }}
+        -DCOVFIE_FAIL_ON_WARNINGS=TRUE
+        -DCOVFIE_BUILD_TESTS=On
+        -DCOVFIE_BUILD_EXAMPLES=On
+        -DCOVFIE_BUILD_BENCHMARKS=On
+        -DCOVFIE_PLATFORM_SYCL=On
+        -DCOVFIE_PLATFORM_CPU=On
+        -DCOVFIE_TEST_HEADERS=On
+        -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }}
+        -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/.prefixes/gtest/"
+        -DCMAKE_CXX_FLAGS="-fsycl"
+        -S $GITHUB_WORKSPACE
+        -B build
+    - name: Build
+      run: cmake --build build -- -j $(nproc)
+    - name: Core tests
+      run: build/tests/core/test_core
+    - name: CPU tests
+      run: build/tests/cpu/test_cpu
+    - name: SYCL tests
+      run: build/tests/sycl/test_sycl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(COVFIE_BUILD_EXAMPLES "Build example executables.")
 option(COVFIE_PLATFORM_CPU "Enable building of CPU code." On)
 option(COVFIE_PLATFORM_OPENMP "Enable building of OpenMP code.")
 option(COVFIE_PLATFORM_CUDA "Enable building of CUDA code.")
+option(COVFIE_PLATFORM_SYCL "Enable building of SYCL code.")
 
 option(COVFIE_FAIL_ON_WARNINGS "Treat compiler warnings as errors.")
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -5,3 +5,4 @@
 add_subdirectory(core)
 add_subdirectory(cpu)
 add_subdirectory(cuda)
+add_subdirectory(sycl)

--- a/lib/core/covfie/core/concepts.hpp
+++ b/lib/core/covfie/core/concepts.hpp
@@ -153,7 +153,7 @@ concept field_backend = requires
 
     requires is_initial<T> || is_constructible_from_config_and_backend<T>;
 
-    {typename T::owning_data_t()};
+    //{typename T::owning_data_t()};
 
     requires requires(typename T::owning_data_t & d)
     {

--- a/lib/sycl/CMakeLists.txt
+++ b/lib/sycl/CMakeLists.txt
@@ -1,0 +1,37 @@
+# SPDX-PackageName: "covfie, a part of the ACTS project"
+# SPDX-FileCopyrightText: 2022 CERN
+# SPDX-License-Identifier: MPL-2.0
+
+add_library(covfie_sycl INTERFACE)
+
+target_include_directories(
+    covfie_sycl
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_compile_features(covfie_sycl INTERFACE cxx_std_20)
+
+target_link_libraries(covfie_sycl INTERFACE covfie_core)
+
+# Logic to ensure that the CUDA module can be installed properly.
+set_target_properties(
+    covfie_sycl
+    PROPERTIES
+        EXPORT_NAME
+            sycl
+)
+
+install(TARGETS covfie_sycl EXPORT ${PROJECT_NAME}Targets)
+
+install(
+    DIRECTORY
+        ${CMAKE_CURRENT_SOURCE_DIR}/covfie
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# Hack for compatibility
+if(NOT PROJECT_IS_TOP_LEVEL)
+    add_library(covfie::sycl ALIAS covfie_sycl)
+endif()

--- a/lib/sycl/covfie/sycl/backend/primitive/sycl_device_array.hpp
+++ b/lib/sycl/covfie/sycl/backend/primitive/sycl_device_array.hpp
@@ -1,0 +1,220 @@
+/*
+ * SPDX-PackageName: "covfie, a part of the ACTS project"
+ * SPDX-FileCopyrightText: 2022 CERN
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <covfie/core/backend/primitive/array.hpp>
+#include <covfie/core/concepts.hpp>
+#include <covfie/core/qualifiers.hpp>
+#include <covfie/core/vector.hpp>
+#include <covfie/sycl/utility/memory.hpp>
+#include <covfie/sycl/utility/unique_ptr.hpp>
+
+namespace covfie::backend {
+template <
+    concepts::vector_descriptor _output_vector_t,
+    typename _index_t = std::size_t>
+struct sycl_device_array {
+    using this_t = sycl_device_array<_output_vector_t, _index_t>;
+
+    static constexpr bool is_initial = true;
+
+    using contravariant_input_t =
+        covfie::vector::scalar_d<covfie::vector::vector_d<_index_t, 1>>;
+    using covariant_output_t =
+        covfie::vector::array_reference_vector_d<_output_vector_t>;
+
+    using output_vector_t = _output_vector_t;
+
+    using value_t = typename output_vector_t::type[output_vector_t::size];
+    using vector_t = std::decay_t<typename covariant_output_t::vector_t>;
+
+    using configuration_t = utility::nd_size<1>;
+
+    static constexpr uint32_t IO_MAGIC_HEADER = 0xAB210000;
+
+    struct owning_data_t {
+        using parent_t = this_t;
+
+        owning_data_t() = delete;
+
+        owning_data_t(::sycl::queue & queue)
+            : m_size(0)
+            , m_queue(queue)
+            , m_ptr({})
+        {
+        }
+
+        owning_data_t(owning_data_t &&) = default;
+        owning_data_t & operator=(owning_data_t &&) = default;
+
+        owning_data_t & operator=(const owning_data_t & o)
+        {
+            m_size = o.m_size;
+            m_ptr.reset();
+            m_queue = o.m_queue;
+            m_ptr =
+                utility::sycl::device_copy_d2d(o.m_ptr.get(), m_size, m_queue);
+
+            return *this;
+        }
+
+        owning_data_t(const owning_data_t & o)
+            : m_size(o.m_size)
+            , m_queue(o.m_queue)
+            , m_ptr(
+                  utility::sycl::device_copy_d2d(o.m_ptr.get(), m_size, m_queue)
+              )
+        {
+            assert(m_size == 0 || m_ptr);
+
+            if (o.m_ptr && m_size > 0) {
+                std::memcpy(
+                    m_ptr.get(), o.m_ptr.get(), m_size * sizeof(vector_t)
+                );
+            }
+        }
+
+        explicit owning_data_t(parameter_pack<owning_data_t> && args)
+            : owning_data_t(std::move(args.x))
+        {
+        }
+
+        // TODO
+        explicit owning_data_t(parameter_pack<configuration_t> && args)
+            : m_size(args.x[0])
+            , m_ptr(utility::sycl::device_allocate<vector_t[]>(m_size, m_queue))
+        {
+        }
+
+        explicit owning_data_t(
+            std::size_t size,
+            std::unique_ptr<vector_t[]> && ptr,
+            ::sycl::queue & queue
+        )
+            : m_size(size)
+            , m_queue(queue)
+            , m_ptr(utility::sycl::device_copy_h2d(ptr.get(), size, m_queue))
+        {
+        }
+
+        template <typename B>
+        requires(!std::same_as<B, owning_data_t> && concepts::array_1d_like_field_backend<typename B::parent_t>) explicit owning_data_t(
+            const B & o, ::sycl::queue & queue
+        )
+            : owning_data_t(o.get_size(), o.get_host_array(), queue)
+        {
+        }
+
+        configuration_t get_configuration() const
+        {
+            return {m_size};
+        }
+
+        static owning_data_t read_binary(std::istream & fs)
+        {
+            utility::read_io_header(fs, IO_MAGIC_HEADER);
+
+            uint32_t float_width = utility::read_binary<uint32_t>(fs);
+
+            if (float_width != 4 && float_width != 8) {
+                throw std::runtime_error(
+                    "Float type is neither IEEE 754 single- nor "
+                    "double-precision, binary input is not supported."
+                );
+            }
+
+            auto size =
+                utility::read_binary<std::decay_t<decltype(m_size)>>(fs);
+            std::unique_ptr<vector_t[]> ptr =
+                std::make_unique<vector_t[]>(size);
+
+            for (std::size_t i = 0; i < size; ++i) {
+                for (std::size_t j = 0; j < _output_vector_t::size; ++j) {
+                    if (float_width == 4) {
+                        ptr[i][j] = utility::read_binary<float>(fs);
+                    } else if (float_width == 8) {
+                        ptr[i][j] = utility::read_binary<double>(fs);
+                    } else {
+                        throw std::logic_error("Float width is unexpected.");
+                    }
+                }
+            }
+
+            utility::read_io_footer(fs, IO_MAGIC_HEADER);
+
+            return owning_data_t(size, std::move(ptr));
+        }
+
+        static void write_binary(std::ostream & fs, const owning_data_t & o)
+        {
+            utility::write_io_header(fs, IO_MAGIC_HEADER);
+
+            uint32_t float_width;
+
+            if constexpr (std::
+                              is_same_v<typename _output_vector_t::type, float>)
+            {
+                float_width = 4;
+            } else if constexpr (std::is_same_v<
+                                     typename _output_vector_t::type,
+                                     double>)
+            {
+                float_width = 8;
+            } else {
+                throw std::logic_error(
+                    "Float type is neither IEEE 754 single- nor "
+                    "double-precision, binary output is not supported."
+                );
+            }
+
+            fs.write(
+                reinterpret_cast<const char *>(&float_width),
+                sizeof(std::decay_t<decltype(float_width)>)
+            );
+
+            fs.write(
+                reinterpret_cast<const char *>(&o.m_size),
+                sizeof(std::decay_t<decltype(o.m_size)>)
+            );
+
+            for (std::size_t i = 0; i < o.m_size; ++i) {
+                for (std::size_t j = 0; j < _output_vector_t::size; ++j) {
+                    fs.write(
+                        reinterpret_cast<const char *>(&o.m_ptr[i][j]),
+                        sizeof(typename _output_vector_t::type)
+                    );
+                }
+            }
+
+            utility::write_io_footer(fs, IO_MAGIC_HEADER);
+        }
+
+        std::size_t m_size;
+        ::sycl::queue m_queue;
+        utility::sycl::unique_device_ptr<vector_t[]> m_ptr;
+    };
+
+    struct non_owning_data_t {
+        using parent_t = this_t;
+
+        non_owning_data_t(const owning_data_t & o)
+            : m_ptr(o.m_ptr.get())
+        {
+        }
+
+        COVFIE_HOST_DEVICE typename covariant_output_t::vector_t
+        at(typename contravariant_input_t::vector_t i) const
+        {
+            return m_ptr[i];
+        }
+
+        vector_t * m_ptr;
+    };
+};
+}

--- a/lib/sycl/covfie/sycl/utility/copy.hpp
+++ b/lib/sycl/covfie/sycl/utility/copy.hpp
@@ -1,0 +1,62 @@
+/*
+ * SPDX-PackageName: "covfie, a part of the ACTS project"
+ * SPDX-FileCopyrightText: 2022 CERN
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <sycl/sycl.hpp>
+
+#include <covfie/core/concepts.hpp>
+
+#include "covfie/core/parameter_pack.hpp"
+
+namespace covfie::utility::sycl {
+template <typename T, typename U>
+requires(concepts::field_backend<T> &&
+             concepts::field_backend<typename std::decay_t<U>::parent_t>)
+    typename T::owning_data_t
+    copy_backend_with_queue(U && backend, ::sycl::queue & queue)
+{
+    constexpr bool can_construct_with_queue =
+        std::constructible_from<typename T::owning_data_t, U, ::sycl::queue &>;
+
+    static_assert(
+        can_construct_with_queue ||
+        (!std::decay_t<T>::is_initial && !std::decay_t<U>::parent_t::is_initial)
+    );
+
+    if constexpr (can_construct_with_queue) {
+        return typename T::owning_data_t(std::forward<U>(backend), queue);
+    } else if constexpr (std::constructible_from<
+                             typename T::owning_data_t,
+                             decltype(backend.get_configuration()),
+                             typename T::backend_t::owning_data_t &&>)
+    {
+        return typename T::owning_data_t(
+            backend.get_configuration(),
+            copy_backend_with_queue<typename T::backend_t>(
+                backend.get_backend(), queue
+            )
+        );
+    } else {
+        return typename T::owning_data_t(make_parameter_pack(
+            backend.get_configuration(),
+            copy_backend_with_queue<typename T::backend_t>(
+                backend.get_backend(), queue
+            )
+        ));
+    }
+}
+
+template <typename T, typename U>
+requires(concepts::field_backend<typename T::backend_t> &&
+             concepts::field_backend<typename std::decay_t<U>::backend_t>) T
+    copy_field_with_queue(U && field, ::sycl::queue & queue)
+{
+    return T(
+        copy_backend_with_queue<typename T::backend_t>(field.backend(), queue)
+    );
+}
+}

--- a/lib/sycl/covfie/sycl/utility/memory.hpp
+++ b/lib/sycl/covfie/sycl/utility/memory.hpp
@@ -1,0 +1,86 @@
+/*
+ * SPDX-PackageName: "covfie, a part of the ACTS project"
+ * SPDX-FileCopyrightText: 2022 CERN
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <sycl/sycl.hpp>
+
+#include <covfie/sycl/utility/unique_ptr.hpp>
+
+namespace covfie::utility::sycl {
+template <typename T>
+unique_device_ptr<T> device_allocate(::sycl::queue & queue)
+{
+    static_assert(
+        !(std::is_array_v<T> && std::extent_v<T> == 0),
+        "Allocation pointer type cannot be an unbounded array."
+    );
+
+    return unique_device_ptr<T>(
+        ::sycl::malloc_device<T>(1, queue), device_deleter(queue)
+    );
+}
+
+template <typename T>
+unique_device_ptr<T> device_allocate(std::size_t n, ::sycl::queue & queue)
+{
+    static_assert(
+        std::is_array_v<T>, "Allocation pointer type must be an array type."
+    );
+    static_assert(
+        std::extent_v<T> == 0, "Allocation pointer type must be unbounded."
+    );
+
+    return unique_device_ptr<T>(
+        ::sycl::malloc_device<std::remove_extent_t<T>>(n, queue),
+        device_deleter(queue)
+    );
+}
+
+template <typename T>
+unique_device_ptr<T[]> device_copy_h2d(const T * h, ::sycl::queue & queue)
+{
+    unique_device_ptr<T[]> r = device_allocate<T[]>(queue);
+
+    queue.memcpy(r.get(), h, sizeof(T)).wait();
+
+    return r;
+}
+
+template <typename T>
+unique_device_ptr<T[]>
+device_copy_h2d(const T * h, std::size_t n, ::sycl::queue & queue)
+{
+    unique_device_ptr<T[]> r = device_allocate<T[]>(n, queue);
+
+    queue.memcpy(r.get(), h, n * sizeof(T)).wait();
+
+    return r;
+}
+
+template <typename T>
+unique_device_ptr<T[]> device_copy_d2d(const T * h, ::sycl::queue & queue)
+{
+    unique_device_ptr<T[]> r = device_allocate<T[]>(queue);
+
+    queue.memcpy(r.get(), h, sizeof(T)).wait();
+
+    return r;
+}
+
+template <typename T>
+unique_device_ptr<T[]>
+device_copy_d2d(const T * h, std::size_t n, ::sycl::queue & queue)
+{
+    unique_device_ptr<T[]> r = device_allocate<T[]>(n, queue);
+
+    queue.memcpy(r.get(), h, n * sizeof(std::remove_extent_t<T>)).wait();
+
+    return r;
+}
+}

--- a/lib/sycl/covfie/sycl/utility/unique_ptr.hpp
+++ b/lib/sycl/covfie/sycl/utility/unique_ptr.hpp
@@ -1,0 +1,35 @@
+/*
+ * SPDX-PackageName: "covfie, a part of the ACTS project"
+ * SPDX-FileCopyrightText: 2022 CERN
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <sycl/sycl.hpp>
+
+namespace covfie::utility::sycl {
+struct device_deleter {
+    device_deleter(const ::sycl::queue & q)
+        : queue(q)
+    {
+    }
+
+    device_deleter(device_deleter &&) = default;
+
+    device_deleter & operator=(device_deleter &&) = default;
+
+    void operator()(void * p) const
+    {
+        ::sycl::free(p, queue);
+    }
+
+private:
+    ::sycl::queue queue;
+};
+
+template <typename T>
+using unique_device_ptr = std::unique_ptr<T, device_deleter>;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,3 +24,8 @@ endif()
 if(COVFIE_PLATFORM_CUDA)
     add_subdirectory(cuda)
 endif()
+
+# The SYCL tests are only built if requested.
+if(COVFIE_PLATFORM_SYCL)
+    add_subdirectory(sycl)
+endif()

--- a/tests/sycl/CMakeLists.txt
+++ b/tests/sycl/CMakeLists.txt
@@ -1,0 +1,16 @@
+# SPDX-PackageName: "covfie, a part of the ACTS project"
+# SPDX-FileCopyrightText: 2022 CERN
+# SPDX-License-Identifier: MPL-2.0
+
+# Create the test executable from the individual test groups.
+add_executable(test_sycl test_sycl_array.cpp)
+
+# Ensure that the tests are linked against the required libraries.
+target_link_libraries(
+    test_sycl
+    PUBLIC
+        covfie_core
+        covfie_sycl
+        GTest::gtest
+        GTest::gtest_main
+)

--- a/tests/sycl/retrieve_vector.hpp
+++ b/tests/sycl/retrieve_vector.hpp
@@ -1,0 +1,30 @@
+/*
+ * SPDX-PackageName: "covfie, a part of the ACTS project"
+ * SPDX-FileCopyrightText: 2022 CERN
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+template <typename F>
+std::decay_t<typename F::output_t> retrieve_vector(
+    typename F::view_t v, typename F::coordinate_t c, ::sycl::queue & queue
+)
+{
+    std::decay_t<typename F::output_t> * rv_d;
+    std::decay_t<typename F::output_t> rv_h;
+
+    rv_d = ::sycl::malloc_device<std::decay_t<typename F::output_t>>(1, queue);
+
+    queue
+        .submit([&](sycl::handler & h) {
+            h.single_task([v, c, rv_d]() { *rv_d = v.at(c); });
+        })
+        .wait();
+
+    queue.memcpy(&rv_h, rv_d, sizeof(std::decay_t<typename F::output_t>))
+        .wait();
+    ::sycl::free(rv_d, queue);
+
+    return rv_h;
+}

--- a/tests/sycl/test_sycl_array.cpp
+++ b/tests/sycl/test_sycl_array.cpp
@@ -1,0 +1,200 @@
+/*
+ * SPDX-PackageName: "covfie, a part of the ACTS project"
+ * SPDX-FileCopyrightText: 2022 CERN
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <optional>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include <covfie/core/backend/primitive/array.hpp>
+#include <covfie/core/backend/transformer/strided.hpp>
+#include <covfie/core/field.hpp>
+#include <covfie/core/field_view.hpp>
+#include <covfie/core/utility/nd_map.hpp>
+#include <covfie/core/vector.hpp>
+#include <covfie/sycl/backend/primitive/sycl_device_array.hpp>
+#include <covfie/sycl/utility/copy.hpp>
+
+#include "retrieve_vector.hpp"
+
+namespace {
+template <std::size_t N, typename T, std::size_t... Is>
+covfie::array::array<T, N>
+create_test_array_helper(std::size_t i, std::index_sequence<Is...> &&)
+{
+    covfie::array::array<T, N> rv;
+    ((rv[Is] = static_cast<T>(i + Is)), ...);
+    return rv;
+}
+
+template <std::size_t N, typename T>
+covfie::array::array<T, N> create_test_array(std::size_t i)
+{
+    return create_test_array_helper<N, T>(i, std::make_index_sequence<N>());
+}
+
+class NameGenerator
+{
+public:
+    template <typename B>
+    static std::string GetName(int)
+    {
+        using scalar_t = typename B::covariant_output_t::scalar_t;
+        constexpr std::size_t dims = B::covariant_output_t::dimensions;
+
+        if constexpr (std::is_same_v<scalar_t, float>) {
+            return "Float[" + std::to_string(dims) + "]";
+        } else if constexpr (std::is_same_v<scalar_t, std::size_t>) {
+            return "UInt64[" + std::to_string(dims) + "]";
+        } else if constexpr (std::is_same_v<scalar_t, int>) {
+            return "Int32[" + std::to_string(dims) + "]";
+        } else if constexpr (std::is_same_v<scalar_t, double>) {
+            return "Double[" + std::to_string(dims) + "]";
+        }
+    }
+};
+}
+
+template <typename B>
+class TestLookupGeneric : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        using vector_t = typename B::covariant_output_t::vector_d;
+        using scalar_t = typename B::covariant_output_t::scalar_t;
+
+        using canonical_backend_t = covfie::backend::array<vector_t>;
+
+        m_size = 1000UL;
+
+        covfie::field<canonical_backend_t> f(covfie::make_parameter_pack(
+            typename canonical_backend_t::configuration_t(m_size)
+        ));
+
+        covfie::field_view<canonical_backend_t> fv(f);
+
+        for (std::size_t i = 0; i < m_size; ++i) {
+            fv.at(i) =
+                create_test_array<B::covariant_output_t::dimensions, scalar_t>(i
+                );
+            ;
+        }
+
+        m_queue = ::sycl::queue(::sycl::default_selector_v);
+
+        m_field =
+            covfie::utility::sycl::copy_field_with_queue<covfie::field<B>>(
+                f, m_queue
+            );
+        m_field_copied = *m_field;
+        m_field_assigned = *m_field;
+        m_field_move_assigned = *m_field;
+        *m_field_assigned = *m_field;
+        covfie::field<B> tmp = *m_field;
+        *m_field_move_assigned = std::move(tmp);
+    }
+
+    ::sycl::queue m_queue;
+    std::size_t m_size;
+    std::optional<covfie::field<B>> m_field;
+    std::optional<covfie::field<B>> m_field_copied;
+    std::optional<covfie::field<B>> m_field_assigned;
+    std::optional<covfie::field<B>> m_field_move_assigned;
+};
+
+template <std::size_t N, typename T>
+using SyclArrayBackend =
+    covfie::backend::sycl_device_array<covfie::vector::vector_d<T, N>>;
+
+// 1D tests
+template <typename B>
+using TestSyclArray = TestLookupGeneric<B>;
+using BackendsInteger1D = ::testing::Types<
+    SyclArrayBackend<1, std::size_t>,
+    SyclArrayBackend<1, int>,
+    SyclArrayBackend<1, float>,
+    SyclArrayBackend<1, double>,
+    SyclArrayBackend<2, std::size_t>,
+    SyclArrayBackend<2, int>,
+    SyclArrayBackend<2, float>,
+    SyclArrayBackend<2, double>,
+    SyclArrayBackend<3, std::size_t>,
+    SyclArrayBackend<3, int>,
+    SyclArrayBackend<3, float>,
+    SyclArrayBackend<3, double>>;
+TYPED_TEST_SUITE(TestSyclArray, BackendsInteger1D, NameGenerator);
+TYPED_TEST(TestSyclArray, LookUpMoveConstructed)
+{
+    for (std::size_t x = 0; x < this->m_size; ++x) {
+        std::decay_t<typename covfie::field<TypeParam>::output_t> o =
+            retrieve_vector<covfie::field<TypeParam>>(
+                *(this->m_field), {x}, this->m_queue
+            );
+
+        EXPECT_EQ(o[0], x);
+        if constexpr (TypeParam::covariant_output_t::dimensions >= 2) {
+            EXPECT_EQ(o[1], x + 1);
+        }
+        if constexpr (TypeParam::covariant_output_t::dimensions >= 3) {
+            EXPECT_EQ(o[2], x + 2);
+        }
+    }
+}
+
+TYPED_TEST(TestSyclArray, LookUpCopyConstructed)
+{
+    for (std::size_t x = 0; x < this->m_size; ++x) {
+        std::decay_t<typename covfie::field<TypeParam>::output_t> o =
+            retrieve_vector<covfie::field<TypeParam>>(
+                *(this->m_field_copied), {x}, this->m_queue
+            );
+
+        EXPECT_EQ(o[0], x);
+        if constexpr (TypeParam::covariant_output_t::dimensions >= 2) {
+            EXPECT_EQ(o[1], x + 1);
+        }
+        if constexpr (TypeParam::covariant_output_t::dimensions >= 3) {
+            EXPECT_EQ(o[2], x + 2);
+        }
+    }
+}
+
+TYPED_TEST(TestSyclArray, LookUpCopyAssigned)
+{
+    for (std::size_t x = 0; x < this->m_size; ++x) {
+        std::decay_t<typename covfie::field<TypeParam>::output_t> o =
+            retrieve_vector<covfie::field<TypeParam>>(
+                *(this->m_field_assigned), {x}, this->m_queue
+            );
+
+        EXPECT_EQ(o[0], x);
+        if constexpr (TypeParam::covariant_output_t::dimensions >= 2) {
+            EXPECT_EQ(o[1], x + 1);
+        }
+        if constexpr (TypeParam::covariant_output_t::dimensions >= 3) {
+            EXPECT_EQ(o[2], x + 2);
+        }
+    }
+}
+
+TYPED_TEST(TestSyclArray, LookUpMoveAssigned)
+{
+    for (std::size_t x = 0; x < this->m_size; ++x) {
+        std::decay_t<typename covfie::field<TypeParam>::output_t> o =
+            retrieve_vector<covfie::field<TypeParam>>(
+                *(this->m_field_move_assigned), {x}, this->m_queue
+            );
+
+        EXPECT_EQ(o[0], x);
+        if constexpr (TypeParam::covariant_output_t::dimensions >= 2) {
+            EXPECT_EQ(o[1], x + 1);
+        }
+        if constexpr (TypeParam::covariant_output_t::dimensions >= 3) {
+            EXPECT_EQ(o[2], x + 2);
+        }
+    }
+}


### PR DESCRIPTION
This commit adds support for SYCL arrays, allowing us to use covfie to represent magnetic fields on Intel GPUs and other devices.