### PR TITLE
Add HIP/CUDA standards to libraries

### DIFF
--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_compile_features(covfie_cuda INTERFACE cxx_std_20)
+target_compile_features(covfie_cuda INTERFACE cxx_std_20 cuda_std_20)
 
 target_link_libraries(covfie_cuda INTERFACE covfie_core)
 

--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -11,7 +11,12 @@ target_include_directories(
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_compile_features(covfie_cuda INTERFACE cxx_std_20 cuda_std_20)
+target_compile_features(
+    covfie_cuda
+    INTERFACE
+        cxx_std_20
+        cuda_std_20
+)
 
 target_link_libraries(covfie_cuda INTERFACE covfie_core)
 

--- a/lib/hip/CMakeLists.txt
+++ b/lib/hip/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_compile_features(covfie_hip INTERFACE cxx_std_20)
+target_compile_features(covfie_hip INTERFACE cxx_std_20 hip_std_20)
 
 target_link_libraries(covfie_hip INTERFACE covfie_core)
 

--- a/lib/hip/CMakeLists.txt
+++ b/lib/hip/CMakeLists.txt
@@ -11,7 +11,12 @@ target_include_directories(
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_compile_features(covfie_hip INTERFACE cxx_std_20 hip_std_20)
+target_compile_features(
+    covfie_hip
+    INTERFACE
+        cxx_std_20
+        hip_std_20
+)
 
 target_link_libraries(covfie_hip INTERFACE covfie_core)
 


### PR DESCRIPTION
Downstream projects that use a public interface less than C++20 require the CUDA compiler to be informed explicitly about the standard required for the CUDA code. The same is true for HIP.