### PR TITLE
Explicitly declare matrix copy assignment

### DIFF
--- a/lib/core/covfie/core/algebra/matrix.hpp
+++ b/lib/core/covfie/core/algebra/matrix.hpp
@@ -33,7 +33,7 @@ struct matrix {
 
     matrix(const matrix<N, M, T, I> &) = default;
 
-    matrix& operator=(const matrix<N, M, T, I> &) = default;
+    matrix & operator=(const matrix<N, M, T, I> &) = default;
 
     COVFIE_HOST_DEVICE T operator()(const I i, const I j) const
     {

--- a/lib/core/covfie/core/algebra/matrix.hpp
+++ b/lib/core/covfie/core/algebra/matrix.hpp
@@ -33,6 +33,8 @@ struct matrix {
 
     matrix(const matrix<N, M, T, I> &) = default;
 
+    matrix& operator=(const matrix<N, M, T, I> &) = default;
+
     COVFIE_HOST_DEVICE T operator()(const I i, const I j) const
     {
         return m_elems[i][j];


### PR DESCRIPTION
Fix a warning by explicitly declaring the copy-assignment operator:
```c++
lib/core/covfie/core/algebra/matrix.hpp:34:5: warning: definition of implicit copy assignment operator for 'matrix<3, 4>' is deprecated because it has a user-declared copy constructor [-Wdeprecated-copy]
   34 |     matrix(const matrix<N, M, T, I> &) = default;
```