### PR TITLE
Explicitly disable the C language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.21)
 
-project("covfie" VERSION 0.12.1)
+project("covfie" VERSION 0.12.1 LANGUAGES CXX)
 
 # Load some dependencies.
 include(GNUInstallDirs)


### PR DESCRIPTION
Calling the `project` function in CMake will, by default, enable both the C and C++ languages. Since we don't use C, this commit explicitly turns that off.