### PR TITLE
Add CMakeGitVersion to auto-fill covfie_VERSION from git metadata

### DIFF
--- a/.gersemirc
+++ b/.gersemirc
@@ -1,3 +1,3 @@
-definitions: [./cmake/CgvFindVersion.cmake, ./cmake/covfie-functions.cmake]
+definitions: [./cmake/CgvFindVersion.cmake]
 line_length: 80
 list_expansion: favour-expansion

--- a/.gersemirc
+++ b/.gersemirc
@@ -1,2 +1,3 @@
+definitions: [./cmake/CgvFindVersion.cmake, ./cmake/covfie-functions.cmake]
 line_length: 80
 list_expansion: favour-expansion

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@
 
 cmake_minimum_required(VERSION 3.21)
 
-project("covfie" VERSION 0.12.1 LANGUAGES CXX)
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/CgvFindVersion.cmake")
+cgv_find_version(covfie)
+project("covfie" VERSION "${covfie_VERSION}" LANGUAGES CXX)
 
 # Load some dependencies.
 include(GNUInstallDirs)

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -23,3 +23,10 @@ path = [
 ]
 SPDX-FileCopyrightText = "2022 CERN"
 SPDX-License-Identifier = "CC0-1.0"
+
+[[annotations]]
+path = [
+        "cmake/.gitattributes",
+]
+SPDX-FileCopyrightText = "CERN and covfie contributors"
+SPDX-License-Identifier = "CC0-1.0"

--- a/cmake/.gitattributes
+++ b/cmake/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes export-ignore
+/CgvFindVersion.cmake export-subst

--- a/cmake/CgvFindVersion.cmake
+++ b/cmake/CgvFindVersion.cmake
@@ -1,6 +1,6 @@
 #------------------------------- -*- cmake -*- -------------------------------#
-# SPDX-PackageName: "CGV: CMake Git Version"
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: "CGV: CMake Git Version"
 #
 # https://github.com/sethrj/cmake-git-version
 #
@@ -87,7 +87,7 @@ To print only the version string (to stderr), and from a custom directory::
 #]=======================================================================]
 
 if(CMAKE_SCRIPT_MODE_FILE)
-  cmake_minimum_required(VERSION 3.8...3.30)
+    cmake_minimum_required(VERSION 3.8...3.30)
 endif()
 
 set(CGV_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
@@ -95,350 +95,432 @@ set(CGV_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 #-----------------------------------------------------------------------------#
 # Get a reproducible timestamp
 macro(_cgv_timestamp tsfile tsvar)
-  if(EXISTS "${tsfile}")
-    file(TIMESTAMP "${tsfile}" ${tsvar} "%Y%m%d.%H%M%S" UTC)
-  else()
-    set(${tsvar} "")
-  endif()
+    if(EXISTS "${tsfile}")
+        file(TIMESTAMP "${tsfile}" ${tsvar} "%Y%m%d.%H%M%S" UTC)
+    else()
+        set(${tsvar} "")
+    endif()
 endmacro()
 
 #-----------------------------------------------------------------------------#
 # Execute a command, logging verbosely, saving output
 macro(_cgv_git_call_output output_var)
-  message(VERBOSE "Executing ${GIT_EXECUTABLE} from ${CGV_SOURCE_DIR}: ${ARGN}")
-  execute_process(
-    COMMAND "${GIT_EXECUTABLE}" ${ARGN}
-    WORKING_DIRECTORY "${CGV_SOURCE_DIR}"
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_VARIABLE GIT_ERR
-    RESULT_VARIABLE GIT_RESULT
-    OUTPUT_VARIABLE ${output_var}
-  )
+    message(
+        VERBOSE
+        "Executing ${GIT_EXECUTABLE} from ${CGV_SOURCE_DIR}: ${ARGN}"
+    )
+    execute_process(
+        COMMAND
+            "${GIT_EXECUTABLE}" ${ARGN}
+        WORKING_DIRECTORY "${CGV_SOURCE_DIR}"
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_VARIABLE GIT_ERR
+        RESULT_VARIABLE GIT_RESULT
+        OUTPUT_VARIABLE ${output_var}
+    )
 endmacro()
 
 #-----------------------------------------------------------------------------#
 # Save the version with a timestamp to a cache variable
 
 function(_cgv_store_version vstring vsuffix vhash tsfile)
-  if(NOT vstring)
-    message(WARNING "The version metadata for ${CGV_PROJECT} could not "
-      "be determined: installed version number may be incorrect")
-  endif()
-  # Replace 11-03 with 11.3
-  string(REGEX REPLACE "-+0*" "." vstring "${vstring}")
-  # Remove trailing periods
-  string(REGEX REPLACE "\\.+$" "" vstring "${vstring}")
-  # Remove leading zeros from version components
-  string(REGEX REPLACE "0+([1-9]+[0-9]*)" "\\1" vstring "${vstring}")
+    if(NOT vstring)
+        message(
+            WARNING
+            "The version metadata for ${CGV_PROJECT} could not "
+            "be determined: installed version number may be incorrect"
+        )
+    endif()
+    # Replace 11-03 with 11.3
+    string(REGEX REPLACE "-+0*" "." vstring "${vstring}")
+    # Remove trailing periods
+    string(REGEX REPLACE "\\.+$" "" vstring "${vstring}")
+    # Remove leading zeros from version components
+    string(REGEX REPLACE "0+([1-9]+[0-9]*)" "\\1" vstring "${vstring}")
 
-  # Get timestamp
-  _cgv_timestamp("${tsfile}" _vtimestamp)
-  # Set up cached data list
-  set(_CACHED_VERSION
-    "${vstring}" "${vsuffix}" "${vhash}" "${tsfile}" "${_vtimestamp}"
-  )
-  # Note: extra 'unset' is necessary if using CMake presets with
-  # ${CGV_PROJECT}_GIT_DESCRIBE="", even with INTERNAL/FORCE
-  unset("${CGV_CACHE_VAR}" CACHE)
-  set("${CGV_CACHE_VAR}" "${_CACHED_VERSION}" CACHE INTERNAL
-    "Version string and hash for ${CGV_PROJECT}")
-  message(VERBOSE "Set ${CGV_CACHE_VAR}=${vstring};${vsuffix};${vhash} from ${tsfile}")
+    # Get timestamp
+    _cgv_timestamp("${tsfile}" _vtimestamp)
+    # Set up cached data list
+    set(_CACHED_VERSION
+        "${vstring}"
+        "${vsuffix}"
+        "${vhash}"
+        "${tsfile}"
+        "${_vtimestamp}"
+    )
+    # Note: extra 'unset' is necessary if using CMake presets with
+    # ${CGV_PROJECT}_GIT_DESCRIBE="", even with INTERNAL/FORCE
+    unset("${CGV_CACHE_VAR}" CACHE)
+    set("${CGV_CACHE_VAR}"
+        "${_CACHED_VERSION}"
+        CACHE INTERNAL
+        "Version string and hash for ${CGV_PROJECT}"
+    )
+    message(
+        VERBOSE
+        "Set ${CGV_CACHE_VAR}=${vstring};${vsuffix};${vhash} from ${tsfile}"
+    )
 endfunction()
 
 #-----------------------------------------------------------------------------#
 # Get the path to the git head used to describe the current repostiory
 function(_cgv_git_path resultvar)
-  if(GIT_EXECUTABLE)
-    _cgv_git_call_output(_TSFILE "rev-parse" "--git-path" "HEAD")
-  else()
-    set(GIT_RESULT 1)
-    set(GIT_ERR "GIT_EXECUTABLE is not defined")
-  endif()
-  if(GIT_RESULT)
-    message(AUTHOR_WARNING "Failed to get path to git head: ${GIT_ERR}")
-    set(_TSFILE)
-  else()
-    get_filename_component(_TSFILE "${_TSFILE}" ABSOLUTE BASE_DIR
-      "${CGV_SOURCE_DIR}"
-    )
-  endif()
+    if(GIT_EXECUTABLE)
+        _cgv_git_call_output(
+            _TSFILE
+            "rev-parse"
+            "--git-path"
+            "HEAD"
+        )
+    else()
+        set(GIT_RESULT 1)
+        set(GIT_ERR "GIT_EXECUTABLE is not defined")
+    endif()
+    if(GIT_RESULT)
+        message(AUTHOR_WARNING "Failed to get path to git head: ${GIT_ERR}")
+        set(_TSFILE)
+    else()
+        get_filename_component(
+            _TSFILE
+            "${_TSFILE}"
+            ABSOLUTE
+            BASE_DIR "${CGV_SOURCE_DIR}"
+        )
+    endif()
 
-  set(${resultvar} "${_TSFILE}" PARENT_SCOPE)
+    set(${resultvar} "${_TSFILE}" PARENT_SCOPE)
 endfunction()
 
 #-----------------------------------------------------------------------------#
 # Process description tag: e.g. v0.4.0-2-gc4af497 or v0.4.0 or v2.0.0-rc.2
 
 function(_cgv_try_parse_git_describe version_string branch_string tsfile)
-  # Regex groups:
-  #  1: primary version (1.2.3)
-  #  2: pre-release: dev/alpha/rc annotation (-rc.1)
-  #  3: post-tag description (-123-gabcd123)
-  #  4: number of commits since (aka distance to) tag (123)
-  #  5: commit hash (abcd213)
-  set(_DESCR_REGEX "^${CGV_TAG_REGEX}(-([0-9]+)-g([0-9a-f]+))?")
-  string(REGEX MATCH "${_DESCR_REGEX}" _MATCH "${version_string}")
-  if(NOT _MATCH)
-    message(AUTHOR_WARNING
-      "Failed to parse description '${version_string}' with regex '${_DESCR_REGEX}'"
+    # Regex groups:
+    #  1: primary version (1.2.3)
+    #  2: pre-release: dev/alpha/rc annotation (-rc.1)
+    #  3: post-tag description (-123-gabcd123)
+    #  4: number of commits since (aka distance to) tag (123)
+    #  5: commit hash (abcd213)
+    set(_DESCR_REGEX "^${CGV_TAG_REGEX}(-([0-9]+)-g([0-9a-f]+))?")
+    string(REGEX MATCH "${_DESCR_REGEX}" _MATCH "${version_string}")
+    if(NOT _MATCH)
+        message(
+            AUTHOR_WARNING
+            "Failed to parse description '${version_string}' with regex '${_DESCR_REGEX}'"
+        )
+        return()
+    endif()
+
+    if(NOT CMAKE_MATCH_3)
+        # This is a tagged release!
+        _cgv_store_version("${CMAKE_MATCH_1}" "${CMAKE_MATCH_2}" "" "${tsfile}")
+        return()
+    endif()
+
+    if(CMAKE_MATCH_2)
+        # After a pre-release, e.g. -rc.1, for SemVer compatibility
+        set(_prerelease "${CMAKE_MATCH_2}.${CMAKE_MATCH_4}")
+    else()
+        # After a release, e.g. -123
+        set(_prerelease "-${CMAKE_MATCH_4}")
+    endif()
+
+    if(branch_string)
+        set(_suffix "${branch_string}.${CMAKE_MATCH_5}")
+    else()
+        set(_suffix "${CMAKE_MATCH_5}")
+    endif()
+
+    # Qualify the version number with the distance-to-tag and hash
+    _cgv_store_version(
+        "${CMAKE_MATCH_1}" # 1.2.3
+        "${_prerelease}" # -rc.2.3, -beta.1, -123
+        "${_suffix}" # abcdef
+        "${tsfile}" # timestamp file
     )
-    return()
-  endif()
-
-  if(NOT CMAKE_MATCH_3)
-    # This is a tagged release!
-    _cgv_store_version("${CMAKE_MATCH_1}" "${CMAKE_MATCH_2}" "" "${tsfile}")
-    return()
-  endif()
-
-  if(CMAKE_MATCH_2)
-    # After a pre-release, e.g. -rc.1, for SemVer compatibility
-    set(_prerelease "${CMAKE_MATCH_2}.${CMAKE_MATCH_4}")
-  else()
-    # After a release, e.g. -123
-    set(_prerelease "-${CMAKE_MATCH_4}")
-  endif()
-
-  if(branch_string)
-    set(_suffix "${branch_string}.${CMAKE_MATCH_5}")
-  else()
-    set(_suffix "${CMAKE_MATCH_5}")
-  endif()
-
-  # Qualify the version number with the distance-to-tag and hash
-  _cgv_store_version(
-    "${CMAKE_MATCH_1}" # 1.2.3
-    "${_prerelease}" # -rc.2.3, -beta.1, -123
-    "${_suffix}" # abcdef
-    "${tsfile}" # timestamp file
-  )
 endfunction()
 
 #-----------------------------------------------------------------------------#
 
 function(_cgv_try_archive_md)
-  # Get a possible Git version generated using git-archive (see the
-  # .gitattributes file)
-  set(_ARCHIVE_DESCR "$Format:%(describe:tags)$")
-  set(_ARCHIVE_TAG "$Format:%D$")
-  set(_ARCHIVE_HASH "$Format:%h$")
-  if(_ARCHIVE_HASH MATCHES "^\\$.*\\$$")
-    # Not a git archive
-    return()
-  endif()
-
-  set(_TSFILE "${CMAKE_CURRENT_LIST_FILE}")
-  string(REGEX MATCH "->\\s+(\\S+)" _MATCH "${_ARCHIVE_TAG}")
-  if(_MATCH)
-    set(_BRANCH "${CMAKE_MATCH_1}")
-  else()
-    set(_BRANCH)
-  endif()
-
-  if(_ARCHIVE_DESCR)
-    _cgv_try_parse_git_describe("${_ARCHIVE_DESCR}" "${_BRANCH}" "${_TSFILE}")
-    if(${CGV_CACHE_VAR})
-      # Successfully parsed description
-      return()
-    endif()
-  endif()
-
-  string(REGEX MATCH "tag: *${CGV_TAG_REGEX}" _MATCH "${_ARCHIVE_TAG}")
-  if(_MATCH)
-    set(_VERSION "${CMAKE_MATCH_1}")
-    set(_SUFFIX "${CMAKE_MATCH_2}")
-    set(_HASH)
-  else()
-    message(AUTHOR_WARNING
-      "Could not match a version tag for "
-      "git description '${_ARCHIVE_TAG}': perhaps this archive was not "
-      "exported from a tagged commit?"
-    )
-    string(REGEX MATCH " *([0-9a-f]+)" _MATCH "${_ARCHIVE_HASH}")
-    if(NOT _MATCH)
-      # Could not even find a git hash
-      return()
+    # Get a possible Git version generated using git-archive (see the
+    # .gitattributes file)
+    set(_ARCHIVE_DESCR "$Format:%(describe:tags)$")
+    set(_ARCHIVE_TAG "$Format:%D$")
+    set(_ARCHIVE_HASH "$Format:%h$")
+    if(_ARCHIVE_HASH MATCHES "^\\$.*\\$$")
+        # Not a git archive
+        return()
     endif()
 
-    # Found a hash but no version
-    set(_VERSION)
-    set(_SUFFIX)
-    set(_HASH "${CMAKE_MATCH_1}")
-  endif()
+    set(_TSFILE "${CMAKE_CURRENT_LIST_FILE}")
+    string(REGEX MATCH "->\\s+(\\S+)" _MATCH "${_ARCHIVE_TAG}")
+    if(_MATCH)
+        set(_BRANCH "${CMAKE_MATCH_1}")
+    else()
+        set(_BRANCH)
+    endif()
 
-  _cgv_store_version("${_VERSION}" "${_SUFFIX}" "${_HASH}" "${_TSFILE}")
+    if(_ARCHIVE_DESCR)
+        _cgv_try_parse_git_describe(
+            "${_ARCHIVE_DESCR}"
+            "${_BRANCH}"
+            "${_TSFILE}"
+        )
+        if(${CGV_CACHE_VAR})
+            # Successfully parsed description
+            return()
+        endif()
+    endif()
+
+    string(REGEX MATCH "tag: *${CGV_TAG_REGEX}" _MATCH "${_ARCHIVE_TAG}")
+    if(_MATCH)
+        set(_VERSION "${CMAKE_MATCH_1}")
+        set(_SUFFIX "${CMAKE_MATCH_2}")
+        set(_HASH)
+    else()
+        message(
+            AUTHOR_WARNING
+            "Could not match a version tag for "
+            "git description '${_ARCHIVE_TAG}': perhaps this archive was not "
+            "exported from a tagged commit?"
+        )
+        string(REGEX MATCH " *([0-9a-f]+)" _MATCH "${_ARCHIVE_HASH}")
+        if(NOT _MATCH)
+            # Could not even find a git hash
+            return()
+        endif()
+
+        # Found a hash but no version
+        set(_VERSION)
+        set(_SUFFIX)
+        set(_HASH "${CMAKE_MATCH_1}")
+    endif()
+
+    _cgv_store_version("${_VERSION}" "${_SUFFIX}" "${_HASH}" "${_TSFILE}")
 endfunction()
 
 #-----------------------------------------------------------------------------#
 # Try git's 'describe' function
 function(_cgv_try_git_describe)
-  # First time calling "git describe"
-  if(NOT Git_FOUND)
-    find_package(Git QUIET)
+    # First time calling "git describe"
     if(NOT Git_FOUND)
-      message(WARNING "Could not find Git, needed to find the version tag")
-      return()
+        find_package(Git QUIET)
+        if(NOT Git_FOUND)
+            message(
+                WARNING
+                "Could not find Git, needed to find the version tag"
+            )
+            return()
+        endif()
     endif()
-  endif()
 
-  if(CGV_TAG_REGEX MATCHES "^\\^?([a-z-]+)")
-    set(_match "--match" "${CMAKE_MATCH_1}*")
-  else()
-    set(_match)
-  endif()
+    if(CGV_TAG_REGEX MATCHES "^\\^?([a-z-]+)")
+        set(_match
+            "--match"
+            "${CMAKE_MATCH_1}*"
+        )
+    else()
+        set(_match)
+    endif()
 
-  # Load git description
-  _cgv_git_call_output(_VERSION_STRING "describe" "--tags" ${_match})
-  if(GIT_RESULT)
-    message(AUTHOR_WARNING "No suitable git tags found': ${GIT_ERR}")
-    return()
-  endif()
-  if(GIT_ERR)
-    message(AUTHOR_WARNING "git describe warned: ${GIT_ERR}")
-  endif()
-  if(NOT _VERSION_STRING)
-    message(AUTHOR_WARNING "Failed to get ${CGV_PROJECT} version from git: "
-      "git describe returned an empty string")
-    return()
-  endif()
+    # Load git description
+    _cgv_git_call_output(
+        _VERSION_STRING
+        "describe"
+        "--tags"
+        ${_match}
+    )
+    if(GIT_RESULT)
+        message(AUTHOR_WARNING "No suitable git tags found': ${GIT_ERR}")
+        return()
+    endif()
+    if(GIT_ERR)
+        message(AUTHOR_WARNING "git describe warned: ${GIT_ERR}")
+    endif()
+    if(NOT _VERSION_STRING)
+        message(
+            AUTHOR_WARNING
+            "Failed to get ${CGV_PROJECT} version from git: "
+            "git describe returned an empty string"
+        )
+        return()
+    endif()
 
-  # Get git branch: may fail if detached, leading to empty output, which is
-  # the desired behavior
-  _cgv_git_call_output(_BRANCH_STRING "symbolic-ref" "--short" "HEAD")
+    # Get git branch: may fail if detached, leading to empty output, which is
+    # the desired behavior
+    _cgv_git_call_output(
+        _BRANCH_STRING
+        "symbolic-ref"
+        "--short"
+        "HEAD"
+    )
 
-  _cgv_git_path(_TSFILE)
-  _cgv_try_parse_git_describe("${_VERSION_STRING}" "${_BRANCH_STRING}" "${_TSFILE}")
+    _cgv_git_path(_TSFILE)
+    _cgv_try_parse_git_describe(
+        "${_VERSION_STRING}"
+        "${_BRANCH_STRING}"
+        "${_TSFILE}"
+    )
 endfunction()
 
 #-----------------------------------------------------------------------------#
 
 function(_cgv_try_git_hash)
-  if(NOT GIT_EXECUTABLE)
-    return()
-  endif()
-  # Fall back to just getting the hash
-  _cgv_git_call_output(_VERSION_HASH "log" "-1" "--format=%h" "HEAD")
-  if(_VERSION_HASH_RESULT)
-    message(AUTHOR_WARNING "Failed to get current commit hash from git: "
-      "${_VERSION_HASH_ERR}")
-    return()
-  endif()
+    if(NOT GIT_EXECUTABLE)
+        return()
+    endif()
+    # Fall back to just getting the hash
+    _cgv_git_call_output(
+        _VERSION_HASH
+        "log"
+        "-1"
+        "--format=%h"
+        "HEAD"
+    )
+    if(_VERSION_HASH_RESULT)
+        message(
+            AUTHOR_WARNING
+            "Failed to get current commit hash from git: "
+            "${_VERSION_HASH_ERR}"
+        )
+        return()
+    endif()
 
-  _cgv_git_path(_TSFILE)
-  _cgv_store_version("" "" "${_VERSION_HASH}" "${_TSFILE}")
+    _cgv_git_path(_TSFILE)
+    _cgv_store_version("" "" "${_VERSION_HASH}" "${_TSFILE}")
 endfunction()
 
 function(_cgv_try_all)
-  if(${CGV_CACHE_VAR})
-    # Previous configure already set the variable: check the timestamp
-    list(LENGTH ${CGV_CACHE_VAR} _len)
-    if(_len EQUAL 5)
-      list(GET ${CGV_CACHE_VAR} 3 _tsfile)
-      list(GET ${CGV_CACHE_VAR} 4 _timestamp)
-    else()
-      message(VERBOSE "Old cache variable ${CGV_CACHE_VAR}: length=${_len}")
-      set(_tsfile)
+    if(${CGV_CACHE_VAR})
+        # Previous configure already set the variable: check the timestamp
+        list(LENGTH ${CGV_CACHE_VAR} _len)
+        if(_len EQUAL 5)
+            list(GET ${CGV_CACHE_VAR} 3 _tsfile)
+            list(GET ${CGV_CACHE_VAR} 4 _timestamp)
+        else()
+            message(
+                VERBOSE
+                "Old cache variable ${CGV_CACHE_VAR}: length=${_len}"
+            )
+            set(_tsfile)
+        endif()
+        if(_tsfile)
+            _cgv_timestamp("${_tsfile}" _curtimestamp)
+            if(_timestamp AND _timestamp STREQUAL _curtimestamp)
+                message(
+                    VERBOSE
+                    "Equal time stamp from ${_tsfile}: ${_timestamp}"
+                )
+                # Time stamp is equal; version doesn't need to be updated
+                return()
+            else()
+                message(
+                    VERBOSE
+                    "Stale timestamp from ${_tsfile}: ${_timestamp} != ${_curtimestamp}"
+                )
+            endif()
+        endif()
+        unset(${CGV_CACHE_VAR} CACHE)
     endif()
-    if(_tsfile)
-      _cgv_timestamp("${_tsfile}" _curtimestamp)
-      if(_timestamp AND _timestamp STREQUAL _curtimestamp)
-        message(VERBOSE "Equal time stamp from ${_tsfile}: ${_timestamp}")
-        # Time stamp is equal; version doesn't need to be updated
+
+    _cgv_try_archive_md()
+    if(${CGV_CACHE_VAR})
         return()
-      else()
-        message(VERBOSE
-          "Stale timestamp from ${_tsfile}: ${_timestamp} != ${_curtimestamp}"
-        )
-      endif()
     endif()
-    unset(${CGV_CACHE_VAR} CACHE)
-  endif()
 
-  _cgv_try_archive_md()
-  if(${CGV_CACHE_VAR})
-    return()
-  endif()
+    _cgv_try_git_describe()
+    if(${CGV_CACHE_VAR})
+        return()
+    endif()
 
-  _cgv_try_git_describe()
-  if(${CGV_CACHE_VAR})
-    return()
-  endif()
+    _cgv_try_git_hash()
+    if(${CGV_CACHE_VAR})
+        return()
+    endif()
 
-  _cgv_try_git_hash()
-  if(${CGV_CACHE_VAR})
-    return()
-  endif()
-
-  # Fallback: no metadata detected
-  set(${CGV_CACHE_VAR} "" "-unknown" "")
+    # Fallback: no metadata detected
+    set(${CGV_CACHE_VAR}
+        ""
+        "-unknown"
+        ""
+    )
 endfunction()
 
 #-----------------------------------------------------------------------------#
 
 function(cgv_find_version)
-  # Set CGV_ variables that are used in embedded macros/functions
-  if(ARGC GREATER 0)
-    set(CGV_PROJECT "${ARGV0}")
-  elseif(NOT CGV_PROJECT)
-    if(NOT CMAKE_PROJECT_NAME)
-      message(FATAL_ERROR "Project name is not defined")
+    # Set CGV_ variables that are used in embedded macros/functions
+    if(ARGC GREATER 0)
+        set(CGV_PROJECT "${ARGV0}")
+    elseif(NOT CGV_PROJECT)
+        if(NOT CMAKE_PROJECT_NAME)
+            message(FATAL_ERROR "Project name is not defined")
+        endif()
+        set(CGV_PROJECT "${CMAKE_PROJECT_NAME}")
     endif()
-    set(CGV_PROJECT "${CMAKE_PROJECT_NAME}")
-  endif()
 
-  if(NOT CGV_TAG_REGEX)
-    set(CGV_TAG_REGEX "v([0-9.]+)(-[a-z]+[0-9.]*)?")
-  endif()
+    if(NOT CGV_TAG_REGEX)
+        set(CGV_TAG_REGEX "v([0-9.]+)(-[a-z]+[0-9.]*)?")
+    endif()
 
-  set(CGV_CACHE_VAR "${CGV_PROJECT}_GIT_DESCRIBE")
+    set(CGV_CACHE_VAR "${CGV_PROJECT}_GIT_DESCRIBE")
 
-  # Try all possible ways of obtaining metadata
-  _cgv_try_all()
+    # Try all possible ways of obtaining metadata
+    _cgv_try_all()
 
-  # Unpack stored version
-  set(_CACHED_VERSION "${${CGV_CACHE_VAR}}")
-  list(GET _CACHED_VERSION 0 _VERSION_STRING)
-  list(GET _CACHED_VERSION 1 _VERSION_STRING_SUFFIX)
-  list(GET _CACHED_VERSION 2 _VERSION_HASH)
-  list(GET _CACHED_VERSION 3 _TSFILE)
+    # Unpack stored version
+    set(_CACHED_VERSION "${${CGV_CACHE_VAR}}")
+    list(GET _CACHED_VERSION 0 _VERSION_STRING)
+    list(GET _CACHED_VERSION 1 _VERSION_STRING_SUFFIX)
+    list(GET _CACHED_VERSION 2 _VERSION_HASH)
+    list(GET _CACHED_VERSION 3 _TSFILE)
 
-  if(NOT _VERSION_STRING)
-    set(_VERSION_STRING "0.0.0")
-  endif()
+    if(NOT _VERSION_STRING)
+        set(_VERSION_STRING "0.0.0")
+    endif()
 
-  if(_VERSION_HASH)
-    set(_FULL_VERSION_STRING "${_VERSION_STRING}${_VERSION_STRING_SUFFIX}+${_VERSION_HASH}")
-  else()
-    set(_FULL_VERSION_STRING "${_VERSION_STRING}${_VERSION_STRING_SUFFIX}")
-  endif()
+    if(_VERSION_HASH)
+        set(_FULL_VERSION_STRING
+            "${_VERSION_STRING}${_VERSION_STRING_SUFFIX}+${_VERSION_HASH}"
+        )
+    else()
+        set(_FULL_VERSION_STRING "${_VERSION_STRING}${_VERSION_STRING_SUFFIX}")
+    endif()
 
-  if(_TSFILE)
-    # Re-run cmake if the timestamp file changes
-    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_TSFILE}")
-  endif()
+    if(_TSFILE)
+        # Re-run cmake if the timestamp file changes
+        set_property(
+            DIRECTORY
+            APPEND
+            PROPERTY
+                CMAKE_CONFIGURE_DEPENDS
+                    "${_TSFILE}"
+        )
+    endif()
 
-  # Set version number and descriptive version in parent scope
-  set(${CGV_PROJECT}_VERSION "${_VERSION_STRING}" PARENT_SCOPE)
-  set(${CGV_PROJECT}_VERSION_STRING "${_FULL_VERSION_STRING}" PARENT_SCOPE)
+    # Set version number and descriptive version in parent scope
+    set(${CGV_PROJECT}_VERSION "${_VERSION_STRING}" PARENT_SCOPE)
+    set(${CGV_PROJECT}_VERSION_STRING "${_FULL_VERSION_STRING}" PARENT_SCOPE)
 endfunction()
 
 #-----------------------------------------------------------------------------#
 
 if(CMAKE_SCRIPT_MODE_FILE)
-  if(DEFINED SOURCE_DIR)
-    set(CGV_SOURCE_DIR ${SOURCE_DIR})
-  endif()
-  cgv_find_version(TEMP)
-  if(DEFINED ONLY)
-    # Print only the given variable, presumably VERSION or VERSION_STRING
-    # (will print to stderr)
-    set(VERSION "${TEMP_VERSION}")
-    set(VERSION_STRING "${TEMP_VERSION_STRING}")
-    message("${${ONLY}}")
-  else()
-    message("VERSION=\"${TEMP_VERSION}\"")
-    message("VERSION_STRING=\"${TEMP_VERSION_STRING}\"")
-  endif()
+    if(DEFINED SOURCE_DIR)
+        set(CGV_SOURCE_DIR ${SOURCE_DIR})
+    endif()
+    cgv_find_version(TEMP)
+    if(DEFINED ONLY)
+        # Print only the given variable, presumably VERSION or VERSION_STRING
+        # (will print to stderr)
+        set(VERSION "${TEMP_VERSION}")
+        set(VERSION_STRING "${TEMP_VERSION_STRING}")
+        message("${${ONLY}}")
+    else()
+        message("VERSION=\"${TEMP_VERSION}\"")
+        message("VERSION_STRING=\"${TEMP_VERSION_STRING}\"")
+    endif()
 endif()
 
-# cmake-git-version 1.2.1-5+main.bdcc7d7
+# cmake-git-version 1.2.2

--- a/cmake/CgvFindVersion.cmake
+++ b/cmake/CgvFindVersion.cmake
@@ -1,0 +1,444 @@
+#------------------------------- -*- cmake -*- -------------------------------#
+# SPDX-PackageName: "CGV: CMake Git Version"
+# SPDX-License-Identifier: Apache-2.0
+#
+# https://github.com/sethrj/cmake-git-version
+#
+# Copyright 2021-2025 UT-Battelle, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#[=======================================================================[.rst:
+
+CgvFindVersion
+--------------
+
+.. command:: cgv_find_version
+
+  Get the project version using Git descriptions to ensure the version numbers
+  are always synchronized between Git and CMake::
+
+    cgv_find_version([<projname>])
+
+  ``<projname>``
+    Name of the project.
+
+  This command sets the numeric (usable in CMake version comparisons) and
+  extended (useful for exact versioning) version variables in the parent
+  package::
+
+    ${projname}_VERSION
+    ${projname}_VERSION_STRING
+
+  It takes the project name as an optional argument so that it may be used
+  *before* calling the CMake ``project`` command.
+
+  The project version string uses an approximation to SemVer strings, appearing
+  as v0.1.2 if the version is actually a tagged release, or
+  v0.1.3-2+branch.abcdef if it's not. Pre-releases should be tagged as
+  v1.0.0-rc.1, and subsequent commits will show as v1.0.0-rc.1.23+branch.abc123.
+
+  If a non-tagged version is exported, or an untagged shallow git clone is used,
+  it's impossible to determine the version from the tag, so a warning will be
+  issued and the version will be set to 0.0.0.
+
+  The default regex used to match the numeric version and full version string
+  from the git tag is::
+
+    v([0-9.]+)(-[a-z]+[0-9.]*)?
+
+  but you can override the regex by setting the ``CGV_TAG_REGEX`` variable
+  before calling ``cgv_find_version``. For example, Geant4 tags such as
+  ``geant4-11-02-ref-09`` can be matched with::
+
+    geant4-([0-9-]+[0-9]+)(-[a-z]+-[0-9]+)?
+
+  Finally, this script records the time stamp of the file used to generate the
+  metadata, and it will re-run cmake if that file changes, and re-run the
+  associated git commands only if the file changes.
+
+  .. note:: In order for this script to work properly with archived git
+    repositories (generated with ``git-archive`` or GitHub's release tarball
+    feature), it's necessary to add to your ``.gitattributes`` file::
+
+      CgvFindVersion.cmake export-subst
+
+    The install script included alongside this file (in the original
+    repository) sets this property.
+
+This script can also be run from the command line to determine git repository
+data::
+
+  cmake -P cmake/CgvFindVersion.cmake
+
+To print only the version string (to stderr), and from a custom directory::
+
+  cmake -DSOURCE_DIR=. -DONLY=VERSION -P cmake/CgvFindVersion.cmake
+
+#]=======================================================================]
+
+if(CMAKE_SCRIPT_MODE_FILE)
+  cmake_minimum_required(VERSION 3.8...3.30)
+endif()
+
+set(CGV_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+#-----------------------------------------------------------------------------#
+# Get a reproducible timestamp
+macro(_cgv_timestamp tsfile tsvar)
+  if(EXISTS "${tsfile}")
+    file(TIMESTAMP "${tsfile}" ${tsvar} "%Y%m%d.%H%M%S" UTC)
+  else()
+    set(${tsvar} "")
+  endif()
+endmacro()
+
+#-----------------------------------------------------------------------------#
+# Execute a command, logging verbosely, saving output
+macro(_cgv_git_call_output output_var)
+  message(VERBOSE "Executing ${GIT_EXECUTABLE} from ${CGV_SOURCE_DIR}: ${ARGN}")
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" ${ARGN}
+    WORKING_DIRECTORY "${CGV_SOURCE_DIR}"
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_VARIABLE GIT_ERR
+    RESULT_VARIABLE GIT_RESULT
+    OUTPUT_VARIABLE ${output_var}
+  )
+endmacro()
+
+#-----------------------------------------------------------------------------#
+# Save the version with a timestamp to a cache variable
+
+function(_cgv_store_version vstring vsuffix vhash tsfile)
+  if(NOT vstring)
+    message(WARNING "The version metadata for ${CGV_PROJECT} could not "
+      "be determined: installed version number may be incorrect")
+  endif()
+  # Replace 11-03 with 11.3
+  string(REGEX REPLACE "-+0*" "." vstring "${vstring}")
+  # Remove trailing periods
+  string(REGEX REPLACE "\\.+$" "" vstring "${vstring}")
+  # Remove leading zeros from version components
+  string(REGEX REPLACE "0+([1-9]+[0-9]*)" "\\1" vstring "${vstring}")
+
+  # Get timestamp
+  _cgv_timestamp("${tsfile}" _vtimestamp)
+  # Set up cached data list
+  set(_CACHED_VERSION
+    "${vstring}" "${vsuffix}" "${vhash}" "${tsfile}" "${_vtimestamp}"
+  )
+  # Note: extra 'unset' is necessary if using CMake presets with
+  # ${CGV_PROJECT}_GIT_DESCRIBE="", even with INTERNAL/FORCE
+  unset("${CGV_CACHE_VAR}" CACHE)
+  set("${CGV_CACHE_VAR}" "${_CACHED_VERSION}" CACHE INTERNAL
+    "Version string and hash for ${CGV_PROJECT}")
+  message(VERBOSE "Set ${CGV_CACHE_VAR}=${vstring};${vsuffix};${vhash} from ${tsfile}")
+endfunction()
+
+#-----------------------------------------------------------------------------#
+# Get the path to the git head used to describe the current repostiory
+function(_cgv_git_path resultvar)
+  if(GIT_EXECUTABLE)
+    _cgv_git_call_output(_TSFILE "rev-parse" "--git-path" "HEAD")
+  else()
+    set(GIT_RESULT 1)
+    set(GIT_ERR "GIT_EXECUTABLE is not defined")
+  endif()
+  if(GIT_RESULT)
+    message(AUTHOR_WARNING "Failed to get path to git head: ${GIT_ERR}")
+    set(_TSFILE)
+  else()
+    get_filename_component(_TSFILE "${_TSFILE}" ABSOLUTE BASE_DIR
+      "${CGV_SOURCE_DIR}"
+    )
+  endif()
+
+  set(${resultvar} "${_TSFILE}" PARENT_SCOPE)
+endfunction()
+
+#-----------------------------------------------------------------------------#
+# Process description tag: e.g. v0.4.0-2-gc4af497 or v0.4.0 or v2.0.0-rc.2
+
+function(_cgv_try_parse_git_describe version_string branch_string tsfile)
+  # Regex groups:
+  #  1: primary version (1.2.3)
+  #  2: pre-release: dev/alpha/rc annotation (-rc.1)
+  #  3: post-tag description (-123-gabcd123)
+  #  4: number of commits since (aka distance to) tag (123)
+  #  5: commit hash (abcd213)
+  set(_DESCR_REGEX "^${CGV_TAG_REGEX}(-([0-9]+)-g([0-9a-f]+))?")
+  string(REGEX MATCH "${_DESCR_REGEX}" _MATCH "${version_string}")
+  if(NOT _MATCH)
+    message(AUTHOR_WARNING
+      "Failed to parse description '${version_string}' with regex '${_DESCR_REGEX}'"
+    )
+    return()
+  endif()
+
+  if(NOT CMAKE_MATCH_3)
+    # This is a tagged release!
+    _cgv_store_version("${CMAKE_MATCH_1}" "${CMAKE_MATCH_2}" "" "${tsfile}")
+    return()
+  endif()
+
+  if(CMAKE_MATCH_2)
+    # After a pre-release, e.g. -rc.1, for SemVer compatibility
+    set(_prerelease "${CMAKE_MATCH_2}.${CMAKE_MATCH_4}")
+  else()
+    # After a release, e.g. -123
+    set(_prerelease "-${CMAKE_MATCH_4}")
+  endif()
+
+  if(branch_string)
+    set(_suffix "${branch_string}.${CMAKE_MATCH_5}")
+  else()
+    set(_suffix "${CMAKE_MATCH_5}")
+  endif()
+
+  # Qualify the version number with the distance-to-tag and hash
+  _cgv_store_version(
+    "${CMAKE_MATCH_1}" # 1.2.3
+    "${_prerelease}" # -rc.2.3, -beta.1, -123
+    "${_suffix}" # abcdef
+    "${tsfile}" # timestamp file
+  )
+endfunction()
+
+#-----------------------------------------------------------------------------#
+
+function(_cgv_try_archive_md)
+  # Get a possible Git version generated using git-archive (see the
+  # .gitattributes file)
+  set(_ARCHIVE_DESCR "$Format:%(describe:tags)$")
+  set(_ARCHIVE_TAG "$Format:%D$")
+  set(_ARCHIVE_HASH "$Format:%h$")
+  if(_ARCHIVE_HASH MATCHES "^\\$.*\\$$")
+    # Not a git archive
+    return()
+  endif()
+
+  set(_TSFILE "${CMAKE_CURRENT_LIST_FILE}")
+  string(REGEX MATCH "->\\s+(\\S+)" _MATCH "${_ARCHIVE_TAG}")
+  if(_MATCH)
+    set(_BRANCH "${CMAKE_MATCH_1}")
+  else()
+    set(_BRANCH)
+  endif()
+
+  if(_ARCHIVE_DESCR)
+    _cgv_try_parse_git_describe("${_ARCHIVE_DESCR}" "${_BRANCH}" "${_TSFILE}")
+    if(${CGV_CACHE_VAR})
+      # Successfully parsed description
+      return()
+    endif()
+  endif()
+
+  string(REGEX MATCH "tag: *${CGV_TAG_REGEX}" _MATCH "${_ARCHIVE_TAG}")
+  if(_MATCH)
+    set(_VERSION "${CMAKE_MATCH_1}")
+    set(_SUFFIX "${CMAKE_MATCH_2}")
+    set(_HASH)
+  else()
+    message(AUTHOR_WARNING
+      "Could not match a version tag for "
+      "git description '${_ARCHIVE_TAG}': perhaps this archive was not "
+      "exported from a tagged commit?"
+    )
+    string(REGEX MATCH " *([0-9a-f]+)" _MATCH "${_ARCHIVE_HASH}")
+    if(NOT _MATCH)
+      # Could not even find a git hash
+      return()
+    endif()
+
+    # Found a hash but no version
+    set(_VERSION)
+    set(_SUFFIX)
+    set(_HASH "${CMAKE_MATCH_1}")
+  endif()
+
+  _cgv_store_version("${_VERSION}" "${_SUFFIX}" "${_HASH}" "${_TSFILE}")
+endfunction()
+
+#-----------------------------------------------------------------------------#
+# Try git's 'describe' function
+function(_cgv_try_git_describe)
+  # First time calling "git describe"
+  if(NOT Git_FOUND)
+    find_package(Git QUIET)
+    if(NOT Git_FOUND)
+      message(WARNING "Could not find Git, needed to find the version tag")
+      return()
+    endif()
+  endif()
+
+  if(CGV_TAG_REGEX MATCHES "^\\^?([a-z-]+)")
+    set(_match "--match" "${CMAKE_MATCH_1}*")
+  else()
+    set(_match)
+  endif()
+
+  # Load git description
+  _cgv_git_call_output(_VERSION_STRING "describe" "--tags" ${_match})
+  if(GIT_RESULT)
+    message(AUTHOR_WARNING "No suitable git tags found': ${GIT_ERR}")
+    return()
+  endif()
+  if(GIT_ERR)
+    message(AUTHOR_WARNING "git describe warned: ${GIT_ERR}")
+  endif()
+  if(NOT _VERSION_STRING)
+    message(AUTHOR_WARNING "Failed to get ${CGV_PROJECT} version from git: "
+      "git describe returned an empty string")
+    return()
+  endif()
+
+  # Get git branch: may fail if detached, leading to empty output, which is
+  # the desired behavior
+  _cgv_git_call_output(_BRANCH_STRING "symbolic-ref" "--short" "HEAD")
+
+  _cgv_git_path(_TSFILE)
+  _cgv_try_parse_git_describe("${_VERSION_STRING}" "${_BRANCH_STRING}" "${_TSFILE}")
+endfunction()
+
+#-----------------------------------------------------------------------------#
+
+function(_cgv_try_git_hash)
+  if(NOT GIT_EXECUTABLE)
+    return()
+  endif()
+  # Fall back to just getting the hash
+  _cgv_git_call_output(_VERSION_HASH "log" "-1" "--format=%h" "HEAD")
+  if(_VERSION_HASH_RESULT)
+    message(AUTHOR_WARNING "Failed to get current commit hash from git: "
+      "${_VERSION_HASH_ERR}")
+    return()
+  endif()
+
+  _cgv_git_path(_TSFILE)
+  _cgv_store_version("" "" "${_VERSION_HASH}" "${_TSFILE}")
+endfunction()
+
+function(_cgv_try_all)
+  if(${CGV_CACHE_VAR})
+    # Previous configure already set the variable: check the timestamp
+    list(LENGTH ${CGV_CACHE_VAR} _len)
+    if(_len EQUAL 5)
+      list(GET ${CGV_CACHE_VAR} 3 _tsfile)
+      list(GET ${CGV_CACHE_VAR} 4 _timestamp)
+    else()
+      message(VERBOSE "Old cache variable ${CGV_CACHE_VAR}: length=${_len}")
+      set(_tsfile)
+    endif()
+    if(_tsfile)
+      _cgv_timestamp("${_tsfile}" _curtimestamp)
+      if(_timestamp AND _timestamp STREQUAL _curtimestamp)
+        message(VERBOSE "Equal time stamp from ${_tsfile}: ${_timestamp}")
+        # Time stamp is equal; version doesn't need to be updated
+        return()
+      else()
+        message(VERBOSE
+          "Stale timestamp from ${_tsfile}: ${_timestamp} != ${_curtimestamp}"
+        )
+      endif()
+    endif()
+    unset(${CGV_CACHE_VAR} CACHE)
+  endif()
+
+  _cgv_try_archive_md()
+  if(${CGV_CACHE_VAR})
+    return()
+  endif()
+
+  _cgv_try_git_describe()
+  if(${CGV_CACHE_VAR})
+    return()
+  endif()
+
+  _cgv_try_git_hash()
+  if(${CGV_CACHE_VAR})
+    return()
+  endif()
+
+  # Fallback: no metadata detected
+  set(${CGV_CACHE_VAR} "" "-unknown" "")
+endfunction()
+
+#-----------------------------------------------------------------------------#
+
+function(cgv_find_version)
+  # Set CGV_ variables that are used in embedded macros/functions
+  if(ARGC GREATER 0)
+    set(CGV_PROJECT "${ARGV0}")
+  elseif(NOT CGV_PROJECT)
+    if(NOT CMAKE_PROJECT_NAME)
+      message(FATAL_ERROR "Project name is not defined")
+    endif()
+    set(CGV_PROJECT "${CMAKE_PROJECT_NAME}")
+  endif()
+
+  if(NOT CGV_TAG_REGEX)
+    set(CGV_TAG_REGEX "v([0-9.]+)(-[a-z]+[0-9.]*)?")
+  endif()
+
+  set(CGV_CACHE_VAR "${CGV_PROJECT}_GIT_DESCRIBE")
+
+  # Try all possible ways of obtaining metadata
+  _cgv_try_all()
+
+  # Unpack stored version
+  set(_CACHED_VERSION "${${CGV_CACHE_VAR}}")
+  list(GET _CACHED_VERSION 0 _VERSION_STRING)
+  list(GET _CACHED_VERSION 1 _VERSION_STRING_SUFFIX)
+  list(GET _CACHED_VERSION 2 _VERSION_HASH)
+  list(GET _CACHED_VERSION 3 _TSFILE)
+
+  if(NOT _VERSION_STRING)
+    set(_VERSION_STRING "0.0.0")
+  endif()
+
+  if(_VERSION_HASH)
+    set(_FULL_VERSION_STRING "${_VERSION_STRING}${_VERSION_STRING_SUFFIX}+${_VERSION_HASH}")
+  else()
+    set(_FULL_VERSION_STRING "${_VERSION_STRING}${_VERSION_STRING_SUFFIX}")
+  endif()
+
+  if(_TSFILE)
+    # Re-run cmake if the timestamp file changes
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_TSFILE}")
+  endif()
+
+  # Set version number and descriptive version in parent scope
+  set(${CGV_PROJECT}_VERSION "${_VERSION_STRING}" PARENT_SCOPE)
+  set(${CGV_PROJECT}_VERSION_STRING "${_FULL_VERSION_STRING}" PARENT_SCOPE)
+endfunction()
+
+#-----------------------------------------------------------------------------#
+
+if(CMAKE_SCRIPT_MODE_FILE)
+  if(DEFINED SOURCE_DIR)
+    set(CGV_SOURCE_DIR ${SOURCE_DIR})
+  endif()
+  cgv_find_version(TEMP)
+  if(DEFINED ONLY)
+    # Print only the given variable, presumably VERSION or VERSION_STRING
+    # (will print to stderr)
+    set(VERSION "${TEMP_VERSION}")
+    set(VERSION_STRING "${TEMP_VERSION_STRING}")
+    message("${${ONLY}}")
+  else()
+    message("VERSION=\"${TEMP_VERSION}\"")
+    message("VERSION_STRING=\"${TEMP_VERSION_STRING}\"")
+  endif()
+endif()
+
+# cmake-git-version 1.2.1-5+main.bdcc7d7

--- a/cmake/covfieConfig.cmake.in
+++ b/cmake/covfieConfig.cmake.in
@@ -6,6 +6,9 @@
 
 include(CMakeFindDependencyMacro)
 
+# Descriptive version string: main version is defined in covfieConfigVersion.cmake
+set(covfie_VERSION_STRING "@covfie_VERSION_STRING@")
+
 include(
     "${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake"
 )


### PR DESCRIPTION
Even though the latest version of Covfie was released through git as v0.13, **the CMake metadata remains at 0.12.1** (and thus the version reported from a spack install is wrong) .  I have added https://github.com/sethrj/cmake-git-version which

Issues for this PR because it won't lint:
- I'm not sure if/how the license of this product should be updated in the REUSE
- REUSE lint also complains a bout missing license in .gitattributes (really?)
- CMake lint complains about missing functions, which there aren't (so I may be misunderstanding it)
- Is there a way to exclude the CMake file from formatting, so it can be diffed against the main version upstream?