### PR TITLE
Fix version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.21)
 
-project("covfie" VERSION 0.12.1 LANGUAGES CXX)
+project("covfie" VERSION 0.13.0 LANGUAGES CXX)
 
 # Load some dependencies.
 include(GNUInstallDirs)


### PR DESCRIPTION
Rather than wait for #83 to finish being reviewed, we can at least patch the CMake-specified version to reflect the latest release. (Then we can use this PR as the basis for a spack patch to ensure the actual release shows up with the correct version.)