### PR TITLE
Fix `owning_data_t` copy assignment

### DIFF
--- a/lib/core/covfie/core/backend/primitive/array.hpp
+++ b/lib/core/covfie/core/backend/primitive/array.hpp
@@ -103,6 +103,7 @@ struct array {
                     m_ptr.get(), o.m_ptr.get(), m_size * sizeof(vector_t)
                 );
             }
+            return *this;
         }
 
         configuration_t get_configuration() const


### PR DESCRIPTION
While reworking covfie usage in Celeritas to no longer use `unique_ptr`, I found that the copy assignment of  `owning_data_t` was missing a return value.