### PR TITLE
Make clamping backend copyable with stream

### DIFF
--- a/lib/core/covfie/core/backend/transformer/clamp.hpp
+++ b/lib/core/covfie/core/backend/transformer/clamp.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <algorithm>
+#include <concepts>
 #include <iostream>
 #include <type_traits>
 #include <variant>
@@ -71,8 +72,10 @@ struct clamp {
         requires(std::same_as<
                  typename backend_t::configuration_t,
                  utility::nd_size<
-                     backend_t::contravariant_input_t::
-                         dimensions>>) explicit owning_data_t(Args... args)
+                     backend_t::contravariant_input_t::dimensions>> &&
+                     std::constructible_from<
+                         typename backend_t::owning_data_t,
+                         Args...>) explicit owning_data_t(Args... args)
             : m_backend(std::forward<Args>(args)...)
         {
             for (std::size_t i = 0; i < contravariant_input_t::dimensions; ++i)

--- a/lib/sycl/covfie/sycl/utility/copy.hpp
+++ b/lib/sycl/covfie/sycl/utility/copy.hpp
@@ -29,24 +29,29 @@ requires(concepts::field_backend<T> &&
 
     if constexpr (can_construct_with_queue) {
         return typename T::owning_data_t(std::forward<U>(backend), queue);
-    } else if constexpr (std::constructible_from<
-                             typename T::owning_data_t,
-                             decltype(backend.get_configuration()),
-                             typename T::backend_t::owning_data_t &&>)
-    {
-        return typename T::owning_data_t(
-            backend.get_configuration(),
-            copy_backend_with_queue<typename T::backend_t>(
-                backend.get_backend(), queue
-            )
-        );
     } else {
-        return typename T::owning_data_t(make_parameter_pack(
-            backend.get_configuration(),
-            copy_backend_with_queue<typename T::backend_t>(
-                backend.get_backend(), queue
-            )
-        ));
+        auto new_backend = copy_backend_with_queue<typename T::backend_t>(
+            backend.get_backend(), queue
+        );
+
+        if constexpr (std::constructible_from<
+                          typename T::owning_data_t,
+                          typename T::backend_t::owning_data_t &&>)
+        {
+            return typename T::owning_data_t(std::move(new_backend));
+        } else if constexpr (std::constructible_from<
+                                 typename T::owning_data_t,
+                                 decltype(backend.get_configuration()),
+                                 typename T::backend_t::owning_data_t &&>)
+        {
+            return typename T::owning_data_t(
+                backend.get_configuration(), std::move(new_backend)
+            );
+        } else {
+            return typename T::owning_data_t(make_parameter_pack(
+                backend.get_configuration(), std::move(new_backend)
+            ));
+        }
     }
 }
 


### PR DESCRIPTION
This commit makes the clamp backend copyable using a stream or a queue by tightening some of its constructor requirements and augmenting the copy utilities to allow backends without explicit configuration.