### PR TITLE
Remove erroneous memory copy from SYCL array

### DIFF
--- a/lib/sycl/covfie/sycl/backend/primitive/sycl_device_array.hpp
+++ b/lib/sycl/covfie/sycl/backend/primitive/sycl_device_array.hpp
@@ -72,12 +72,6 @@ struct sycl_device_array {
               )
         {
             assert(m_size == 0 || m_ptr);
-
-            if (o.m_ptr && m_size > 0) {
-                std::memcpy(
-                    m_ptr.get(), o.m_ptr.get(), m_size * sizeof(vector_t)
-                );
-            }
         }
 
         explicit owning_data_t(parameter_pack<owning_data_t> && args)


### PR DESCRIPTION
Removed erroneous host based copy for SYCL device memory. Which lead to issues as soon as using a SYCL device that would have its own device memory.

I tested with [traccc](https://github.com/acts-project/traccc) that things seem to work fine without this `std::memcpy` present. Since the memory is already copied correctly in lines 70-72.