### PR TITLE
Fix off-by-one error in clamp backend

### DIFF
--- a/lib/core/covfie/core/backend/transformer/clamp.hpp
+++ b/lib/core/covfie/core/backend/transformer/clamp.hpp
@@ -81,7 +81,8 @@ struct clamp {
             for (std::size_t i = 0; i < contravariant_input_t::dimensions; ++i)
             {
                 m_min[i] = 0;
-                m_max[i] = m_backend.get_configuration()[i];
+                assert(m_backend.get_configuration()[i] > 0);
+                m_max[i] = m_backend.get_configuration()[i] - 1;
             }
         }
 


### PR DESCRIPTION
The clamp backend, when constructed over a natural-number-delimited underlying field, previously assumed the clamp limit to be off by one. Indeed, `clamp(a, n, b)` can return `b` inclusively. It was previously assumed that this was exclusive. Subtracting one from the clamp parameters fixes this issue.