### PR TITLE
Remove use of target_compile_features for HIP

### DIFF
--- a/lib/hip/CMakeLists.txt
+++ b/lib/hip/CMakeLists.txt
@@ -17,9 +17,14 @@ target_include_directories(
 #        cxx_std_20
 #        hip_std_20
 #)
-set_target_properties(covfie_hip PROPERTIES
-                      HIP_STANDARD 20 
-                      HIP_STANDARD_REQUIRED ON)
+set_target_properties(
+    covfie_hip
+    PROPERTIES
+        HIP_STANDARD
+            20
+        HIP_STANDARD_REQUIRED
+            ON
+)
 
 target_link_libraries(covfie_hip INTERFACE covfie_core)
 

--- a/lib/hip/CMakeLists.txt
+++ b/lib/hip/CMakeLists.txt
@@ -11,12 +11,15 @@ target_include_directories(
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_compile_features(
-    covfie_hip
-    INTERFACE
-        cxx_std_20
-        hip_std_20
-)
+#target_compile_features(
+#    covfie_hip
+#    INTERFACE
+#        cxx_std_20
+#        hip_std_20
+#)
+set_target_properties(covfie_hip PROPERTIES
+                      HIP_STANDARD 20 
+                      HIP_STANDARD_REQUIRED ON)
 
 target_link_libraries(covfie_hip INTERFACE covfie_core)
 


### PR DESCRIPTION
Seems to be broken even in cmake 4.0.1, when included from traccc. I didn't manage to reproduce this in a standalone way to report to cmake developers. Should be easier to reproduce when https://github.com/acts-project/traccc/pull/1202 is in.