### PR TITLE
fix: hilbert backend: `calculate_index(c, sizes)` missing second arg

### DIFF
--- a/lib/core/covfie/core/backend/transformer/hilbert.hpp
+++ b/lib/core/covfie/core/backend/transformer/hilbert.hpp
@@ -115,7 +115,7 @@ struct hilbert {
         typename T::parent_t::non_owning_data_t nother(other);
 
         utility::nd_map<decltype(sizes)>(
-            [&nother, &res](decltype(sizes) t) {
+            [&nother, &res, &sizes](decltype(sizes) t) {
                 coordinate_t c;
 
                 for (std::size_t i = 0; i < contravariant_input_t::dimensions;
@@ -123,7 +123,7 @@ struct hilbert {
                     c[i] = t[i];
                 }
 
-                std::size_t idx = calculate_index(c);
+                std::size_t idx = calculate_index(c, sizes);
 
                 for (std::size_t i = 0; i < covariant_output_t::dimensions; ++i)
                 {
@@ -263,7 +263,7 @@ struct hilbert {
             }
 #endif
 
-            return m_storage.at(calculate_index(c));
+            return m_storage.at(calculate_index(c, m_sizes));
         }
 
         typename backend_t::non_owning_data_t & get_backend(void)

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(
     test_canonical.cpp
     test_atlas_like_io.cpp
     test_covariant_cast.cpp
+    test_hilbert_layout.cpp
 )
 
 # Ensure that the tests are linked against the required libraries.

--- a/tests/core/test_hilbert_layout.cpp
+++ b/tests/core/test_hilbert_layout.cpp
@@ -1,0 +1,51 @@
+/*
+ * SPDX-PackageName: "covfie, a part of the ACTS project"
+ * SPDX-FileCopyrightText: 2022 CERN
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <cstddef>
+
+#include <gtest/gtest.h>
+
+#include <covfie/core/backend/primitive/array.hpp>
+#include <covfie/core/backend/transformer/hilbert.hpp>
+#include <covfie/core/backend/transformer/strided.hpp>
+#include <covfie/core/field.hpp>
+#include <covfie/core/parameter_pack.hpp>
+#include <covfie/core/vector.hpp>
+
+TEST(TestHilbertLayout, RoundTrip2D)
+{
+    // Build a 4x4 strided field backed by a writable array
+    using strided_t = covfie::field<covfie::backend::strided<
+        covfie::vector::size2,
+        covfie::backend::array<covfie::vector::float1>>>;
+
+    strided_t src(covfie::make_parameter_pack(
+        strided_t::backend_t::configuration_t{4u, 4u}
+    ));
+    strided_t::view_t sv(src);
+
+    for (std::size_t x = 0; x < 4; ++x) {
+        for (std::size_t y = 0; y < 4; ++y) {
+            sv.at(x, y)[0] = static_cast<float>(x * 4 + y);
+        }
+    }
+
+    // Copy into a hilbert field - exercises make_hilbert_copy
+    using hilbert_t = covfie::field<covfie::backend::hilbert<
+        covfie::vector::size2,
+        covfie::backend::array<covfie::vector::float1>>>;
+
+    hilbert_t dst(src);
+
+    // Read back via at() - exercises non_owning_data_t::at()
+    hilbert_t::view_t hv(dst);
+
+    for (std::size_t x = 0; x < 4; ++x) {
+        for (std::size_t y = 0; y < 4; ++y) {
+            EXPECT_EQ(hv.at(x, y)[0], static_cast<float>(x * 4 + y));
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes incorrect arguments for `calculate_index` in the Hilbert backend. This is in a template so not compiled until used. A test was added to instantiate the relevant functions (thanks to copilot for the test drudgery).