### PR TITLE
fix: include cstdint when using uint32_t

### DIFF
--- a/lib/core/covfie/core/backend/primitive/array.hpp
+++ b/lib/core/covfie/core/backend/primitive/array.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <utility>

--- a/lib/core/covfie/core/utility/binary_io.hpp
+++ b/lib/core/covfie/core/utility/binary_io.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <sstream>


### PR DESCRIPTION
This PR adds two header includes to ensure compilation on clang-23 tip-of-main, since `uint32_t` is not otherwise available and not included transitively.