### PR TITLE
Correctly return success from pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -20,3 +20,5 @@ do
         !(git show $local_oid:CMakeLists.txt | grep "project(\"covfie\" VERSION ${tagname:1:10000} LANGUAGES CXX)" > /dev/null) && echo "CMakeLists.txt version is wrongly set!" && exit 1
     fi
 done
+
+exit 0


### PR DESCRIPTION
This commit makes the pre-push hook return a succesful 0 status.