### PR TITLE
Add a covariant arity reduction transformer

### DIFF
--- a/lib/core/covfie/core/backend/transformer/covariant_select.hpp
+++ b/lib/core/covfie/core/backend/transformer/covariant_select.hpp
@@ -1,0 +1,134 @@
+/*
+ * SPDX-PackageName: "covfie, a part of the ACTS project"
+ * SPDX-FileCopyrightText: 2022 CERN
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <iostream>
+#include <variant>
+
+#include <covfie/core/concepts.hpp>
+#include <covfie/core/definitions.hpp>
+#include <covfie/core/parameter_pack.hpp>
+#include <covfie/core/qualifiers.hpp>
+#include <covfie/core/utility/binary_io.hpp>
+#include <covfie/core/vector.hpp>
+
+namespace covfie::backend {
+template <concepts::field_backend _backend_t, std::size_t... Is>
+struct covariant_select {
+    using this_t = covariant_select<_backend_t, Is...>;
+    static constexpr bool is_initial = false;
+
+    using backend_t = _backend_t;
+
+    using contravariant_input_t = typename backend_t::contravariant_input_t;
+    using covariant_output_t = vector::array_vector_d<vector::vector_d<
+        typename backend_t::covariant_output_t::scalar_t,
+        sizeof...(Is)>>;
+
+    static_assert(
+        sizeof...(Is) > 0, "covariant_select must select at least one element."
+    );
+    static_assert(
+        ((Is < backend_t::covariant_output_t::dimensions) && ...),
+        "covariant_select indices must be in range of the wrapped backend's "
+        "covariant output dimensions."
+    );
+
+    using configuration_t = std::monostate;
+
+    static constexpr uint32_t IO_MAGIC_HEADER = 0xAB020011;
+
+    struct owning_data_t {
+        using parent_t = this_t;
+
+        owning_data_t() = default;
+
+        template <typename... Args>
+        explicit owning_data_t(configuration_t, Args... args)
+            : m_backend(std::forward<Args>(args)...)
+        {
+        }
+
+        explicit owning_data_t(parameter_pack<owning_data_t> && conf)
+            : owning_data_t(std::move(conf.x))
+        {
+        }
+
+        template <typename... Args>
+        explicit owning_data_t(parameter_pack<configuration_t, Args...> && args)
+            : m_backend(std::move(args.xs))
+        {
+        }
+
+        explicit owning_data_t(
+            const configuration_t &, typename backend_t::owning_data_t && b
+        )
+            : m_backend(b)
+        {
+        }
+
+        typename backend_t::owning_data_t & get_backend(void)
+        {
+            return m_backend;
+        }
+
+        const typename backend_t::owning_data_t & get_backend(void) const
+        {
+            return m_backend;
+        }
+
+        configuration_t get_configuration(void) const
+        {
+            return {};
+        }
+
+        static owning_data_t read_binary(std::istream & fs)
+        {
+            auto be = decltype(m_backend)::read_binary(fs);
+
+            return owning_data_t(configuration_t{}, std::move(be));
+        }
+
+        static void write_binary(std::ostream & fs, const owning_data_t & o)
+        {
+            decltype(m_backend)::write_binary(fs, o.m_backend);
+        }
+
+        typename backend_t::owning_data_t m_backend;
+    };
+
+    struct non_owning_data_t {
+        using parent_t = this_t;
+
+        non_owning_data_t(const owning_data_t & src)
+            : m_backend(src.m_backend)
+        {
+        }
+
+        COVFIE_HOST_DEVICE typename covariant_output_t::vector_t
+        at(typename contravariant_input_t::vector_t c) const
+        {
+            decltype(auto) v = m_backend.at(c);
+            return {
+                static_cast<typename covariant_output_t::scalar_t>(v[Is])...};
+        }
+
+        typename backend_t::non_owning_data_t & get_backend(void)
+        {
+            return m_backend;
+        }
+
+        const typename backend_t::non_owning_data_t & get_backend(void) const
+        {
+            return m_backend;
+        }
+
+        typename backend_t::non_owning_data_t m_backend;
+    };
+};
+}

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(
     test_canonical.cpp
     test_atlas_like_io.cpp
     test_covariant_cast.cpp
+    test_covariant_select.cpp
     test_hilbert_layout.cpp
 )
 

--- a/tests/core/test_covariant_select.cpp
+++ b/tests/core/test_covariant_select.cpp
@@ -1,0 +1,80 @@
+/*
+ * SPDX-PackageName: "covfie, a part of the ACTS project"
+ * SPDX-FileCopyrightText: 2022 CERN
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <covfie/core/backend/primitive/identity.hpp>
+#include <covfie/core/backend/transformer/covariant_select.hpp>
+#include <covfie/core/field.hpp>
+
+TEST(TestCovariantSelect, Identity3DSelect1)
+{
+    using field_t = covfie::field<covfie::backend::covariant_select<
+        covfie::backend::identity<covfie::vector::int3>,
+        1>>;
+
+    field_t f(covfie::make_parameter_pack(
+        field_t::backend_t::configuration_t({}),
+        field_t::backend_t::backend_t::configuration_t({})
+    ));
+    field_t::view_t fv(f);
+
+    for (int x = -2; x < 2; x++) {
+        for (int y = -2; y < 2; y++) {
+            for (int z = -2; z < 2; z++) {
+                EXPECT_EQ(fv.at(x, y, z)[0], y);
+            }
+        }
+    }
+}
+
+TEST(TestCovariantSelect, Identity3DSelect20)
+{
+    using field_t = covfie::field<covfie::backend::covariant_select<
+        covfie::backend::identity<covfie::vector::int3>,
+        2,
+        0>>;
+
+    field_t f(covfie::make_parameter_pack(
+        field_t::backend_t::configuration_t({}),
+        field_t::backend_t::backend_t::configuration_t({})
+    ));
+    field_t::view_t fv(f);
+
+    for (int x = -2; x < 2; x++) {
+        for (int y = -2; y < 2; y++) {
+            for (int z = -2; z < 2; z++) {
+                EXPECT_EQ(fv.at(x, y, z)[0], z);
+                EXPECT_EQ(fv.at(x, y, z)[1], x);
+            }
+        }
+    }
+}
+
+TEST(TestCovariantSelect, Identity3DSelectAll)
+{
+    using field_t = covfie::field<covfie::backend::covariant_select<
+        covfie::backend::identity<covfie::vector::int3>,
+        0,
+        1,
+        2>>;
+
+    field_t f(covfie::make_parameter_pack(
+        field_t::backend_t::configuration_t({}),
+        field_t::backend_t::backend_t::configuration_t({})
+    ));
+    field_t::view_t fv(f);
+
+    for (int x = -2; x < 2; x++) {
+        for (int y = -2; y < 2; y++) {
+            for (int z = -2; z < 2; z++) {
+                EXPECT_EQ(fv.at(x, y, z)[0], x);
+                EXPECT_EQ(fv.at(x, y, z)[1], y);
+                EXPECT_EQ(fv.at(x, y, z)[2], z);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit adds `covariant_select` a transformer which reduces (and possibly reorders) the dimensions of the covariant part of a vector field. This is designed primarily for 3D to 2D projections as well as for writing tests.