### PR TITLE
Fix use of uninitialized size in CUDA device array

### DIFF
--- a/lib/cuda/covfie/cuda/backend/primitive/cuda_device_array.hpp
+++ b/lib/cuda/covfie/cuda/backend/primitive/cuda_device_array.hpp
@@ -90,7 +90,7 @@ struct cuda_device_array {
         }
 
         explicit owning_data_t(parameter_pack<configuration_t> && args)
-            : owning_data_t(args.x[0], std::make_unique<vector_t[]>(m_size))
+            : owning_data_t(args.x[0], std::make_unique<vector_t[]>(args.x[0]))
         {
         }
 
@@ -105,7 +105,8 @@ struct cuda_device_array {
             parameter_pack<configuration_t> && args, cudaStream_t stream
         )
             : owning_data_t(
-                  args.x[0], utility::cuda::device_allocate<vector_t[]>(m_size)
+                  args.x[0],
+                  utility::cuda::device_allocate<vector_t[]>(args.x[0])
               )
         {
         }


### PR DESCRIPTION
`cuda_device_array::owning_data_t` has two delegating constructors
taking a `parameter_pack<configuration_t>` (the plain overload and the
stream overload). Both size the buffer they allocate from the member
`m_size`:

    : owning_data_t(args.x[0], std::make_unique<vector_t[]>(m_size))

`m_size` is only assigned by the constructor these delegate to, which
runs after this argument list is evaluated, so `m_size` is still
uninitialized when it is read here. The allocation ends up sized from
an indeterminate value, as reported in #95.

Fix: size the buffer from the requested length, `args.x[0]`, in both
constructors. Constructing a field from a bare configuration segfaults
before this change and succeeds afterwards (checked on an NVIDIA T4).

Closes #95.
