### PR TITLE
Fix the installation docs and document the test suite

### DIFF
--- a/docs/developer/build.rst
+++ b/docs/developer/build.rst
@@ -1,2 +1,98 @@
+.. _building:
+
 Building
 ========
+
+The library itself is header-only, so building covfie is only necessary if you
+want to run the tests, the examples or the benchmarks. The build is driven by
+CMake and requires CMake 3.21 or newer and a C++20 compiler.
+
+Build options
+-------------
+
+The following options select which parts of the repository are built. All three
+are off by default, and all three require covfie to be the top level project;
+they are rejected if covfie is pulled in through :code:`add_subdirectory` or
+:code:`FetchContent`.
+
+.. list-table::
+    :header-rows: 1
+
+    * - Option
+      - Effect
+    * - :code:`COVFIE_BUILD_TESTS`
+      - Build the test executables.
+    * - :code:`COVFIE_BUILD_EXAMPLES`
+      - Build the example executables.
+    * - :code:`COVFIE_BUILD_BENCHMARKS`
+      - Build the benchmark executables.
+
+The platform options below decide which platforms that code is built for. Only
+:code:`COVFIE_PLATFORM_CPU` is on by default. They do not affect which headers
+are installed.
+
+.. list-table::
+    :header-rows: 1
+
+    * - Option
+      - Effect
+    * - :code:`COVFIE_PLATFORM_CPU`
+      - Enable building of CPU code. On by default.
+    * - :code:`COVFIE_PLATFORM_OPENMP`
+      - Enable building of OpenMP code.
+    * - :code:`COVFIE_PLATFORM_CUDA`
+      - Enable building of CUDA code.
+    * - :code:`COVFIE_PLATFORM_SYCL`
+      - Enable building of SYCL code.
+    * - :code:`COVFIE_PLATFORM_HIP`
+      - Enable building of HIP code.
+
+Finally, :code:`COVFIE_FAIL_ON_WARNINGS` turns compiler warnings into errors,
+which is what the continuous integration uses.
+
+Dependencies
+------------
+
+The tests need Google Test and the benchmarks need Google Benchmark. Neither is
+downloaded during the build, so they have to be available beforehand. The
+easiest way to get them is the Spack environment included in the repository:
+
+.. code-block:: console
+
+    $ spack env create covfie spack.yaml
+    $ spack -e covfie concretize -f
+    $ spack -e covfie install
+    $ spack env activate covfie
+
+If you already have them installed somewhere else, point CMake at that location
+with :code:`-DCMAKE_PREFIX_PATH=[path]` instead.
+
+Building and running the tests
+------------------------------
+
+.. code-block:: console
+
+    $ cmake -S covfie -B build -DCOVFIE_BUILD_TESTS=On
+    $ cmake --build build
+
+This produces one test executable per enabled platform. With the default
+options that is:
+
+.. code-block:: console
+
+    $ ./build/tests/core/test_core
+    $ ./build/tests/cpu/test_cpu
+
+The tests are not registered with CTest, so run the executables directly rather
+than through :code:`ctest`. Each of them is an ordinary Google Test binary, so
+the usual flags such as :code:`--gtest_filter` work as expected.
+
+Building the examples
+---------------------
+
+The examples are built in the same way, and end up in :code:`build/examples`:
+
+.. code-block:: console
+
+    $ cmake -S covfie -B build -DCOVFIE_BUILD_EXAMPLES=On
+    $ cmake --build build

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -23,12 +23,50 @@ you can specify this desire as follows:
 It is also possible to obtain the source code through other means, of course,
 but we will not cover those methods here.
 
+Requirements
+------------
+
+Installing the library requires CMake 3.21 or newer. Compiling code against it
+requires a C++20 compiler, as the headers use concepts. The CUDA, SYCL and HIP
+parts of the library additionally require the compiler and runtime of the
+platform in question.
+
+Building the tests, examples or benchmarks has further requirements, which are
+covered in :ref:`the build guide <building>`.
+
+Installing with CMake
+---------------------
+
 You will need to determine where you want to install covfie. In the following
 instructions, the installation path will be denoted :code:`[prefix]`. To
 install covfie, proceed with the following commands:
 
 .. code-block:: console
 
-    $ cmake -S covfie -B covfie_build -DCMAKE_INSTALL_PREFIX=[prefix] -DCOVFIE_PLATFORM_CPU=On -DCOVFIE_PLATFORM_CUDA=On
-    $ cmake --build build
-    $ cmake --install build
+    $ cmake -S covfie -B covfie_build -DCMAKE_INSTALL_PREFIX=[prefix]
+    $ cmake --build covfie_build
+    $ cmake --install covfie_build
+
+This places the headers for all platforms in :code:`[prefix]/include/covfie`
+and the CMake package files in :code:`[prefix]/share/covfie/cmake`. The
+:code:`COVFIE_PLATFORM_*` options have no effect here, as they only select
+which platform code is built for the tests, examples and benchmarks.
+
+Using the headers directly
+--------------------------
+
+Because the library is header-only, you can also skip CMake and point the
+compiler at the headers yourself, either in an installation prefix:
+
+.. code-block:: console
+
+    $ c++ -std=c++20 -I [prefix]/include my_application.cpp
+
+or straight from a checkout, without installing anything at all:
+
+.. code-block:: console
+
+    $ c++ -std=c++20 -I covfie/lib/core my_application.cpp
+
+The headers for the other platforms live in :code:`covfie/lib/cpu`,
+:code:`covfie/lib/cuda`, :code:`covfie/lib/sycl` and :code:`covfie/lib/hip`.

--- a/docs/user/integration.rst
+++ b/docs/user/integration.rst
@@ -27,7 +27,7 @@ includes covfie, consider the following:
     project("my_application")
     find_package(covfie REQUIRED)
     add_executable(main main.cpp)
-    target_link_libraries(main PUBLIC covfie::covfie_core)
+    target_link_libraries(main PUBLIC covfie::core)
 
 In order for CMake to be able to find the necessary setup files, it must be
 instructed to look in the installation prefix chosen during :ref:`installation


### PR DESCRIPTION
The installation page already existed but didn't work if you followed it. It configures into `covfie_build` and then builds and installs from `build`, so the second command just errors out, and it passes `COVFIE_PLATFORM_CUDA=On` which does nothing for an install since the platform options only pick what the tests, examples and benchmarks get built for. I fixed the paths, added the CMake and compiler requirements, and wrote out the plain `-I` route properly, since the page mentioned copying headers around without showing what that looks like.

The developer build page was just a heading, so that's where the test suite part of the issue went. It now covers the build options, the fact that Google Test and Google Benchmark have to be there already rather than being fetched during the build, and how to build and run the tests. Worth calling out: the tests aren't registered with CTest, so `ctest` reports "No tests were found" and you have to run the executables yourself. I documented that rather than hiding it, but if you'd rather I add `gtest_discover_tests` and make ctest work, I can do that in a separate PR.

The third commit is a one word fix in the integration page. The complete example there links `covfie::covfie_core`, but the exported name is `covfie::core`, so that example fails at configure time. It's not strictly part of this issue, so say the word if you want it split off.

Everything here was run on macOS with clang 21 and CMake 4.4 before writing it down: install into a prefix, downstream `find_package` build, compiling against the headers with no CMake at all, and `COVFIE_BUILD_TESTS=On` giving `test_core` (100 tests) and `test_cpu` (7 tests), both passing. Sphinx builds the docs clean with `-W`.

Closes #93
