### PR TITLE
Fix several issues in backend serialization

### DIFF
--- a/lib/core/covfie/core/backend/transformer/covariant_cast.hpp
+++ b/lib/core/covfie/core/backend/transformer/covariant_cast.hpp
@@ -86,7 +86,7 @@ struct covariant_cast {
 
         static void write_binary(std::ostream & fs, const owning_data_t & o)
         {
-            decltype(m_backend)::write_binary(fs, o);
+            decltype(m_backend)::write_binary(fs, o.m_backend);
         }
 
         typename backend_t::owning_data_t m_backend;

--- a/lib/core/covfie/core/backend/transformer/dereference.hpp
+++ b/lib/core/covfie/core/backend/transformer/dereference.hpp
@@ -85,7 +85,7 @@ struct dereference {
 
         static void write_binary(std::ostream & fs, const owning_data_t & o)
         {
-            decltype(m_backend)::write_binary(fs, o);
+            decltype(m_backend)::write_binary(fs, o.m_backend);
         }
 
         typename backend_t::owning_data_t m_backend;

--- a/lib/core/covfie/core/utility/binary_io.hpp
+++ b/lib/core/covfie/core/utility/binary_io.hpp
@@ -85,7 +85,7 @@ inline std::istream & read_io_header(std::istream & fs, uint32_t hdr)
         std::stringstream err;
         err << "Deserialization of covfie vector field due to non-matching "
                "backend header (should be 0x"
-            << std::hex << std::uppercase << hdr << ", but was 0x" << hdr1
+            << std::hex << std::uppercase << hdr << ", but was 0x" << hdr2
             << ")";
         throw std::runtime_error(err.str());
     }

--- a/lib/cuda/covfie/cuda/backend/primitive/cuda_device_array.hpp
+++ b/lib/cuda/covfie/cuda/backend/primitive/cuda_device_array.hpp
@@ -210,10 +210,18 @@ struct cuda_device_array {
                 sizeof(std::decay_t<decltype(o.m_size)>)
             );
 
+            /*
+             * The data lives in device memory, which the host cannot read
+             * directly, so we stage it back to the host before we write it.
+             */
+            std::unique_ptr<vector_t[]> host = utility::cuda::device_copy_d2h(
+                o.m_ptr.get(), o.m_size, o.m_stream
+            );
+
             for (std::size_t i = 0; i < o.m_size; ++i) {
                 for (std::size_t j = 0; j < _output_vector_t::size; ++j) {
                     fs.write(
-                        reinterpret_cast<const char *>(&o.m_ptr[i][j]),
+                        reinterpret_cast<const char *>(&host[i][j]),
                         sizeof(typename _output_vector_t::type)
                     );
                 }

--- a/lib/cuda/covfie/cuda/utility/memory.hpp
+++ b/lib/cuda/covfie/cuda/utility/memory.hpp
@@ -151,4 +151,35 @@ unique_device_ptr<T[]> device_copy_d2d(
 
     return r;
 }
+
+template <typename T>
+std::unique_ptr<T[]> device_copy_d2h(
+    const T * d,
+    std::size_t n,
+    std::optional<cudaStream_t> stream = std::nullopt
+)
+{
+    std::unique_ptr<T[]> r = std::make_unique<T[]>(n);
+
+    if (stream.has_value()) {
+        cudaErrorCheck(cudaMemcpyAsync(
+            r.get(),
+            d,
+            n * sizeof(std::remove_extent_t<T>),
+            cudaMemcpyDeviceToHost,
+            *stream
+        ));
+        cudaErrorCheck(cudaStreamSynchronize(*stream));
+    } else {
+        cudaErrorCheck(cudaMemcpy(
+            r.get(),
+            d,
+            n * sizeof(std::remove_extent_t<T>),
+            cudaMemcpyDeviceToHost
+        ));
+    }
+
+    return r;
+}
+
 }

--- a/lib/hip/covfie/hip/backend/primitive/hip_device_array.hpp
+++ b/lib/hip/covfie/hip/backend/primitive/hip_device_array.hpp
@@ -209,10 +209,18 @@ struct hip_device_array {
                 sizeof(std::decay_t<decltype(o.m_size)>)
             );
 
+            /*
+             * The data lives in device memory, which the host cannot read
+             * directly, so we stage it back to the host before we write it.
+             */
+            std::unique_ptr<vector_t[]> host = utility::hip::device_copy_d2h(
+                o.m_ptr.get(), o.m_size, o.m_stream
+            );
+
             for (std::size_t i = 0; i < o.m_size; ++i) {
                 for (std::size_t j = 0; j < _output_vector_t::size; ++j) {
                     fs.write(
-                        reinterpret_cast<const char *>(&o.m_ptr[i][j]),
+                        reinterpret_cast<const char *>(&host[i][j]),
                         sizeof(typename _output_vector_t::type)
                     );
                 }

--- a/lib/hip/covfie/hip/utility/memory.hpp
+++ b/lib/hip/covfie/hip/utility/memory.hpp
@@ -145,4 +145,33 @@ unique_device_ptr<T[]> device_copy_d2d(
 
     return r;
 }
+
+template <typename T>
+std::unique_ptr<T[]> device_copy_d2h(
+    const T * d, std::size_t n, std::optional<hipStream_t> stream = std::nullopt
+)
+{
+    std::unique_ptr<T[]> r = std::make_unique<T[]>(n);
+
+    if (stream.has_value()) {
+        hipErrorCheck(hipMemcpyAsync(
+            r.get(),
+            d,
+            n * sizeof(std::remove_extent_t<T>),
+            hipMemcpyDeviceToHost,
+            *stream
+        ));
+        hipErrorCheck(hipStreamSynchronize(*stream));
+    } else {
+        hipErrorCheck(hipMemcpy(
+            r.get(),
+            d,
+            n * sizeof(std::remove_extent_t<T>),
+            hipMemcpyDeviceToHost
+        ));
+    }
+
+    return r;
+}
+
 }

--- a/lib/sycl/covfie/sycl/backend/primitive/sycl_device_array.hpp
+++ b/lib/sycl/covfie/sycl/backend/primitive/sycl_device_array.hpp
@@ -177,10 +177,18 @@ struct sycl_device_array {
                 sizeof(std::decay_t<decltype(o.m_size)>)
             );
 
+            /*
+             * The data lives in device memory, which the host cannot read
+             * directly, so we stage it back to the host before we write it.
+             */
+            ::sycl::queue queue = o.m_queue;
+            std::unique_ptr<vector_t[]> host =
+                utility::sycl::device_copy_d2h(o.m_ptr.get(), o.m_size, queue);
+
             for (std::size_t i = 0; i < o.m_size; ++i) {
                 for (std::size_t j = 0; j < _output_vector_t::size; ++j) {
                     fs.write(
-                        reinterpret_cast<const char *>(&o.m_ptr[i][j]),
+                        reinterpret_cast<const char *>(&host[i][j]),
                         sizeof(typename _output_vector_t::type)
                     );
                 }

--- a/lib/sycl/covfie/sycl/utility/memory.hpp
+++ b/lib/sycl/covfie/sycl/utility/memory.hpp
@@ -83,4 +83,15 @@ device_copy_d2d(const T * h, std::size_t n, ::sycl::queue & queue)
 
     return r;
 }
+
+template <typename T>
+std::unique_ptr<T[]>
+device_copy_d2h(const T * d, std::size_t n, ::sycl::queue & queue)
+{
+    std::unique_ptr<T[]> r = std::make_unique<T[]>(n);
+
+    queue.memcpy(r.get(), d, n * sizeof(std::remove_extent_t<T>)).wait();
+
+    return r;
+}
 }

--- a/tests/core/test_binary_io.cpp
+++ b/tests/core/test_binary_io.cpp
@@ -4,13 +4,18 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <cstdint>
+#include <cstring>
 #include <fstream>
+#include <sstream>
 
 #include <boost/filesystem.hpp>
 #include <gtest/gtest.h>
 #include <tmp_file.hpp>
 
 #include <covfie/core/backend/primitive/array.hpp>
+#include <covfie/core/backend/transformer/dereference.hpp>
+#include <covfie/core/backend/transformer/strided.hpp>
 #include <covfie/core/field.hpp>
 
 TEST(TestBinaryIO, WriteRead1DSingleFloatBuilder)
@@ -186,3 +191,75 @@ TEST(TestBinaryIO, WriteRead1DSingleFloatBuilder)
 //     EXPECT_EQ(nfb.at_integral(2u, 3u, 3u)[0], 233.0f);
 //     EXPECT_EQ(nfb.at_integral(2u, 3u, 4u)[0], 234.0f);
 // }
+
+TEST(TestBinaryIO, WriteReadDereference2D)
+{
+    using field_t =
+        covfie::field<covfie::backend::dereference<covfie::backend::strided<
+            covfie::vector::size2,
+            covfie::backend::array<covfie::vector::float2>>>>;
+    using inner_field_t = covfie::field<typename field_t::backend_t::backend_t>;
+
+    inner_field_t inner(covfie::make_parameter_pack(
+        inner_field_t::backend_t::configuration_t{3ul, 4ul}
+    ));
+    inner_field_t::view_t inner_view(inner);
+
+    for (std::size_t x = 0ul; x < 3ul; ++x) {
+        for (std::size_t y = 0ul; y < 4ul; ++y) {
+            inner_view.at(x, y)[0] = static_cast<float>(x);
+            inner_view.at(x, y)[1] = static_cast<float>(y);
+        }
+    }
+
+    field_t f(field_t::storage_t(
+        field_t::backend_t::configuration_t{}, inner.backend()
+    ));
+
+    std::stringstream ss;
+
+    f.dump(ss);
+
+    field_t nf(ss);
+    field_t::view_t nfv(nf);
+
+    for (std::size_t x = 0ul; x < 3ul; ++x) {
+        for (std::size_t y = 0ul; y < 4ul; ++y) {
+            EXPECT_EQ(nfv.at(x, y)[0], static_cast<float>(x));
+            EXPECT_EQ(nfv.at(x, y)[1], static_cast<float>(y));
+        }
+    }
+}
+
+TEST(TestBinaryIO, ReadWrongBackendHeaderReportsItsValue)
+{
+    using field_t =
+        covfie::field<covfie::backend::array<covfie::vector::float1>>;
+
+    field_t f(covfie::make_parameter_pack(field_t::backend_t::configuration_t{
+        2ul}));
+
+    std::stringstream ss;
+
+    f.dump(ss);
+
+    /*
+     * The backend header is the second word of the stream. Corrupt it, and
+     * check that the error names the value that was actually found rather
+     * than the global header that preceded it.
+     */
+    std::string data = ss.str();
+    const std::uint32_t bad = 0xDEADBEEF;
+    std::memcpy(data.data() + sizeof(std::uint32_t), &bad, sizeof(bad));
+
+    std::stringstream bs(data);
+
+    try {
+        field_t nf(bs);
+        FAIL() << "Deserialization of a corrupt header must throw.";
+    } catch (const std::runtime_error & e) {
+        EXPECT_NE(std::string(e.what()).find("DEADBEEF"), std::string::npos)
+            << "Error message should report the header that was found: "
+            << e.what();
+    }
+}

--- a/tests/core/test_covariant_cast.cpp
+++ b/tests/core/test_covariant_cast.cpp
@@ -6,12 +6,15 @@
 
 #include <cmath>
 #include <cstddef>
+#include <sstream>
 
 #include <gtest/gtest.h>
 
+#include <covfie/core/backend/primitive/array.hpp>
 #include <covfie/core/backend/primitive/identity.hpp>
 #include <covfie/core/backend/transformer/covariant_cast.hpp>
 #include <covfie/core/backend/transformer/linear.hpp>
+#include <covfie/core/backend/transformer/strided.hpp>
 #include <covfie/core/field.hpp>
 
 TEST(TestCovariantCast, Identity1D)
@@ -70,6 +73,46 @@ TEST(TestCovariantCast, Identity3D)
                 EXPECT_EQ(fv.at(x, y, z)[1], y);
                 EXPECT_EQ(fv.at(x, y, z)[2], z);
             }
+        }
+    }
+}
+
+TEST(TestCovariantCast, WriteReadStrided2D)
+{
+    using field_t = covfie::field<covfie::backend::covariant_cast<
+        double,
+        covfie::backend::strided<
+            covfie::vector::size2,
+            covfie::backend::array<covfie::vector::float2>>>>;
+    using inner_field_t = covfie::field<typename field_t::backend_t::backend_t>;
+
+    inner_field_t inner(covfie::make_parameter_pack(
+        inner_field_t::backend_t::configuration_t{3ul, 4ul}
+    ));
+    inner_field_t::view_t inner_view(inner);
+
+    for (std::size_t x = 0ul; x < 3ul; ++x) {
+        for (std::size_t y = 0ul; y < 4ul; ++y) {
+            inner_view.at(x, y)[0] = static_cast<float>(x);
+            inner_view.at(x, y)[1] = static_cast<float>(y);
+        }
+    }
+
+    field_t f(field_t::storage_t(
+        field_t::backend_t::configuration_t{}, inner.backend()
+    ));
+
+    std::stringstream ss;
+
+    f.dump(ss);
+
+    field_t nf(ss);
+    field_t::view_t nfv(nf);
+
+    for (std::size_t x = 0ul; x < 3ul; ++x) {
+        for (std::size_t y = 0ul; y < 4ul; ++y) {
+            EXPECT_EQ(nfv.at(x, y)[0], static_cast<double>(x));
+            EXPECT_EQ(nfv.at(x, y)[1], static_cast<double>(y));
         }
     }
 }


### PR DESCRIPTION
This commit fixes several issues in backend serialization, including (but not limited to) missing function arguments and serializing the wrong objects. It also adds tests for this functionality.