### PR TITLE
Fix size-derived constructor of backup backend

### DIFF
--- a/lib/core/covfie/core/backend/transformer/backup.hpp
+++ b/lib/core/covfie/core/backend/transformer/backup.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <iostream>
 #include <type_traits>
 #include <variant>
@@ -88,16 +89,21 @@ struct backup {
                          dimensions>>) explicit owning_data_t(Args... args)
             : m_backend(std::forward<Args>(args)...)
         {
-            m_min.fill(static_cast<typename contravariant_input_t::scalar_t>(0)
-            );
-
             for (std::size_t i = 0; i < contravariant_input_t::dimensions; ++i)
             {
-                m_max[i] = m_backend.get_configuration()[i];
+                m_min[i] =
+                    static_cast<typename contravariant_input_t::scalar_t>(0);
+                assert(m_backend.get_configuration()[i] > 0);
+                m_max[i] =
+                    static_cast<typename contravariant_input_t::scalar_t>(
+                        m_backend.get_configuration()[i] - 1
+                    );
             }
 
-            m_default.fill(static_cast<typename covariant_output_t::scalar_t>(0)
-            );
+            for (std::size_t i = 0; i < covariant_output_t::dimensions; ++i) {
+                m_default[i] =
+                    static_cast<typename covariant_output_t::scalar_t>(0);
+            }
         }
 
         typename backend_t::owning_data_t & get_backend(void)

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(
     test_constant_field.cpp
     test_transformer_affine.cpp
     test_transformer_clamp.cpp
+    test_transformer_backup.cpp
     test_binary_io.cpp
     test_identity_backend.cpp
     test_nearest_neighbour_interpolator.cpp

--- a/tests/core/test_transformer_backup.cpp
+++ b/tests/core/test_transformer_backup.cpp
@@ -1,0 +1,93 @@
+/*
+ * SPDX-PackageName: "covfie, a part of the ACTS project"
+ * SPDX-FileCopyrightText: 2022 CERN
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <cstddef>
+
+#include <gtest/gtest.h>
+
+#include <covfie/core/backend/primitive/array.hpp>
+#include <covfie/core/backend/transformer/backup.hpp>
+#include <covfie/core/backend/transformer/strided.hpp>
+#include <covfie/core/field.hpp>
+#include <covfie/core/parameter_pack.hpp>
+
+namespace {
+using inner_backend_t = covfie::backend::strided<
+    covfie::vector::size2,
+    covfie::backend::array<covfie::vector::float2>>;
+using field_t = covfie::field<covfie::backend::backup<inner_backend_t>>;
+
+/*
+ * Build a 4x4 field of f(x, y) = (x, y), guarded by a backup layer which
+ * derives its bounds from the size of the underlying field.
+ */
+field_t make_field()
+{
+    using inner_field_t = covfie::field<inner_backend_t>;
+
+    inner_field_t inner(
+        covfie::make_parameter_pack(inner_backend_t::configuration_t{4ul, 4ul})
+    );
+    inner_field_t::view_t inner_view(inner);
+
+    for (std::size_t x = 0ul; x < 4ul; ++x) {
+        for (std::size_t y = 0ul; y < 4ul; ++y) {
+            inner_view.at(x, y)[0] = static_cast<float>(x);
+            inner_view.at(x, y)[1] = static_cast<float>(y);
+        }
+    }
+
+    return field_t(field_t::storage_t(inner.backend()));
+}
+}
+
+TEST(TestTransformerBackup, ConfigurationFromBackendSize)
+{
+    field_t f = make_field();
+
+    field_t::backend_t::configuration_t conf = f.backend().get_configuration();
+
+    /*
+     * A 4x4 field has valid indices zero through three, and the bounds of the
+     * backup layer are inclusive, so the maximum must be three and not four.
+     */
+    for (std::size_t i = 0ul; i < 2ul; ++i) {
+        EXPECT_EQ(conf.min[i], 0ul);
+        EXPECT_EQ(conf.max[i], 3ul);
+        EXPECT_EQ(conf.default_value[i], 0.f);
+    }
+}
+
+TEST(TestTransformerBackup, InRangeLookup)
+{
+    field_t f = make_field();
+    field_t::view_t fv(f);
+
+    for (std::size_t x = 0ul; x < 4ul; ++x) {
+        for (std::size_t y = 0ul; y < 4ul; ++y) {
+            EXPECT_EQ(fv.at(x, y)[0], static_cast<float>(x));
+            EXPECT_EQ(fv.at(x, y)[1], static_cast<float>(y));
+        }
+    }
+}
+
+TEST(TestTransformerBackup, OutOfRangeLookupGivesDefault)
+{
+    field_t f = make_field();
+    field_t::view_t fv(f);
+
+    /*
+     * Index four lies one past the end of the 4x4 field in both dimensions,
+     * so the backup layer must return the default value instead of reading
+     * out of bounds.
+     */
+    for (std::size_t i = 0ul; i < 5ul; ++i) {
+        EXPECT_EQ(fv.at(4ul, i)[0], 0.f);
+        EXPECT_EQ(fv.at(4ul, i)[1], 0.f);
+        EXPECT_EQ(fv.at(i, 4ul)[0], 0.f);
+        EXPECT_EQ(fv.at(i, 4ul)[1], 0.f);
+    }
+}


### PR DESCRIPTION
The backup backend can derive its bounds from the size of the field that it wraps. That constructor had two defects, which are fixed in this commit. They relate to the use of a non-extant method on the size array, and the inclusivity of the underlying backend.