### PR TITLE
Use non-narrowing round in nearest neighbour

### DIFF
--- a/lib/core/covfie/core/backend/transformer/nearest_neighbour.hpp
+++ b/lib/core/covfie/core/backend/transformer/nearest_neighbour.hpp
@@ -132,7 +132,7 @@ struct nearest_neighbour {
             for (std::size_t i = 0; i < contravariant_output_t::dimensions; ++i)
             {
                 nc[i] = static_cast<typename contravariant_output_t::scalar_t>(
-                    std::lrintf(c[i])
+                    std::lrint(c[i])
                 );
             }
 

--- a/tests/core/test_nearest_neighbour_interpolator.cpp
+++ b/tests/core/test_nearest_neighbour_interpolator.cpp
@@ -158,3 +158,29 @@ TEST(TestNearestNeighbourInterpolator, Identity3Nto3F)
     EXPECT_EQ(fv.at(-25.74f, -60.98f, -41.86f)[1], -61);
     EXPECT_EQ(fv.at(-25.74f, -60.98f, -41.86f)[2], -42);
 }
+
+TEST(TestNearestNeighbourInterpolator, Identity1Nto1D)
+{
+    using field_t = covfie::field<covfie::backend::nearest_neighbour<
+        covfie::backend::identity<covfie::vector::int1>,
+        covfie::vector::double1>>;
+
+    field_t f(covfie::make_parameter_pack(
+        field_t::backend_t::configuration_t({}),
+        field_t::backend_t::backend_t::configuration_t({})
+    ));
+    field_t::view_t fv(f);
+
+    EXPECT_EQ(fv.at(5.4)[0], 5);
+    EXPECT_EQ(fv.at(5.6)[0], 6);
+    EXPECT_EQ(fv.at(-1.51)[0], -2);
+
+    /*
+     * These coordinates lie just below a half-way point in double
+     * precision, but round up to it in single precision. They therefore
+     * catch a lookup which narrows the coordinate to a float first.
+     */
+    EXPECT_EQ(fv.at(3.4999999999999996)[0], 3);
+    EXPECT_EQ(fv.at(5.499999999999999)[0], 5);
+    EXPECT_EQ(fv.at(-3.4999999999999996)[0], -3);
+}


### PR DESCRIPTION
The nearest neighbour interpolator rounds its input coordinate with `std::lrintf`, which takes a `float`. The backend accepts any floating point scalar type, so a backend parameterised on `double` has every coordinate narrowed to single precision before it was rounded. This commit moves to using the more generic, non-narrowing `std::lrint`.