### PR TITLE
Fix scalar readout of CUDA texture backend

### DIFF
--- a/lib/cuda/covfie/cuda/backend/primitive/cuda_texture.hpp
+++ b/lib/cuda/covfie/cuda/backend/primitive/cuda_texture.hpp
@@ -389,7 +389,7 @@ struct cuda_texture {
             }
 
             if constexpr (_output_vector_t::size == 1) {
-                return {r.x};
+                return {r};
             } else if constexpr (_output_vector_t::size == 2) {
                 return {r.x, r.y};
             } else if constexpr (_output_vector_t::size == 3) {


### PR DESCRIPTION
The CUDA texture returns a scalar float but the current code assumes that it returns a vector-like struct. This commit moves to a non-member accessor to resolve this issue.