### PR TITLE
Add a code coverage build option and CI job

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -74,6 +74,61 @@ jobs:
     - name: CPU tests
       run: build/tests/cpu/test_cpu
 
+  linux-coverage:
+    name: "Linux/Coverage"
+
+    runs-on: "ubuntu-latest"
+
+    container: ubuntu:24.04
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: apt-get update && apt-get -y install
+        libboost-filesystem-dev
+        libboost-program-options-dev
+        libboost-log-dev
+        wget
+        cmake
+        g++
+        gcovr
+    - name: Install Google Test
+      run: |
+        wget https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+        tar -xzvf v1.14.0.tar.gz
+        cmake -S googletest-1.14.0 -B gtest_build -DBUILD_GMOCK=Off -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/.prefixes/gtest/
+        cmake --build gtest_build -- -j $(nproc)
+        cmake --install gtest_build
+    - name: Configure
+      run: cmake
+        -DCMAKE_CXX_COMPILER=$(which g++)
+        -DCMAKE_BUILD_TYPE=Debug
+        -DCOVFIE_BUILD_TESTS=On
+        -DCOVFIE_BUILD_COVERAGE=On
+        -DCMAKE_CXX_STANDARD=20
+        -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/.prefixes/gtest/"
+        -S $GITHUB_WORKSPACE
+        -B build
+    - name: Build
+      run: cmake --build build -- -j $(nproc)
+    - name: Core tests
+      run: build/tests/core/test_core
+    - name: CPU tests
+      run: build/tests/cpu/test_cpu
+    # gcovr reads its filters from gcovr.cfg in the root of the repository.
+    - name: Report coverage
+      run: |
+        mkdir coverage
+        gcovr --root $GITHUB_WORKSPACE build \
+          --print-summary \
+          --cobertura coverage/cobertura.xml \
+          --html-details coverage/index.html
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: coverage/
+
   linux-cuda:
     strategy:
       matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ option(COVFIE_PLATFORM_HIP "Enable building of HIP code.")
 
 option(COVFIE_FAIL_ON_WARNINGS "Treat compiler warnings as errors.")
 
+# Code coverage instrumentation. Use a Debug build with this option, because
+# the inlining done at higher optimisation levels makes the report inaccurate.
+option(COVFIE_BUILD_COVERAGE "Build with code coverage instrumentation.")
+
 # Make the CMake modules in the cmake/ directory visible to the project.
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,37 @@ spack -e covfie install
 spack env activate covfie
 ```
 
+## Measuring test coverage
+
+Configure a Debug build with `COVFIE_BUILD_COVERAGE`, run the tests, then
+build the report with [gcovr](https://gcovr.com/):
+
+```
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCOVFIE_BUILD_TESTS=On \
+    -DCOVFIE_BUILD_COVERAGE=On
+cmake --build build
+build/tests/core/test_core && build/tests/cpu/test_cpu
+gcovr --root . build --html-details coverage/index.html
+```
+
+The build directory is a positional argument to gcovr, and gcovr reads its
+filters from `gcovr.cfg` in the root of the repository. Use a Debug build,
+because the inlining done at higher optimisation levels distorts the result.
+
+Two things stop the report from measuring code that no release build
+contains. The coverage option defines `NDEBUG`, which removes the assertions
+and the blocks that the library guards with `#ifndef NDEBUG`; be aware that
+assertions therefore do not fire in a coverage build. `gcovr.cfg` then passes
+`--exclude-throw-branches`, which drops the hidden branch that the compiler
+adds to every call that may throw. Together these two raised the reported
+branch coverage from 58% to 89% without a single test changing, because the
+branches they remove were never reachable from a test.
+
+Note that covfie is a header-only template library, so gcov counts each line
+once per template instantiation. A header that is instantiated eight times
+contributes eight times its length to the totals. Branch coverage is the more
+useful of the two numbers.
+
 ## Citation
 
 If you use covfie in your research, please cite the following paper:

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -17,6 +17,7 @@ path = [
         "CITATION.cff",
         ".clang-format",
         ".gersemirc",
+        "gcovr.cfg",
         ".gitignore",
         ".pre-commit-config.yaml",
         ".readthedocs.yml",

--- a/cmake/covfie-compiler-options-cpp.cmake
+++ b/cmake/covfie-compiler-options-cpp.cmake
@@ -36,6 +36,39 @@ if(PROJECT_IS_TOP_LEVEL)
         if(COVFIE_FAIL_ON_WARNINGS)
             covfie_add_flag( CMAKE_CXX_FLAGS "-Werror" )
         endif()
+
+        # Instrument the code for coverage, if asked for that behaviour.
+        if(COVFIE_BUILD_COVERAGE)
+            covfie_add_flag( CMAKE_CXX_FLAGS "--coverage" )
+            covfie_add_flag( CMAKE_EXE_LINKER_FLAGS "--coverage" )
+
+            # gcov must find the headers again when it writes the report, and
+            # it cannot do so from a build directory outside the source tree
+            # unless the paths are absolute. Clang has no such flag, but it
+            # records absolute paths anyway.
+            if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+                covfie_add_flag( CMAKE_CXX_FLAGS "-fprofile-abs-path" )
+            endif()
+
+            # An assertion compiles to a branch whose false side only aborts
+            # the process, and the library also guards whole blocks with
+            # `#ifndef NDEBUG`. None of that reaches a release build, so it
+            # would only dilute the report. Define NDEBUG to measure the code
+            # that ships.
+            covfie_add_flag( CMAKE_CXX_FLAGS "-DNDEBUG" )
+
+            message(
+                STATUS
+                "Coverage is enabled, so NDEBUG is defined and assertions are disabled in this build."
+            )
+
+            if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+                message(
+                    WARNING
+                    "Coverage is enabled in a ${CMAKE_BUILD_TYPE} build. Use a Debug build, because inlining distorts the report."
+                )
+            endif()
+        endif()
     elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
         # Basic flags for all build modes.
         string(REGEX REPLACE "/W[0-9]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
@@ -48,5 +81,28 @@ if(PROJECT_IS_TOP_LEVEL)
 
         # Turn on the correct setting for the __cplusplus macro with MSVC.
         covfie_add_flag( CMAKE_CXX_FLAGS "/Zc:__cplusplus" )
+    endif()
+
+    # Coverage is only wired up for the GCC and Clang flag syntax, so tell the
+    # user when the request has no effect rather than reporting nothing later.
+    if(
+        COVFIE_BUILD_COVERAGE
+        AND NOT (
+            (
+                "${CMAKE_CXX_COMPILER_ID}"
+                    MATCHES
+                    "GNU"
+            )
+            OR (
+                "${CMAKE_CXX_COMPILER_ID}"
+                    MATCHES
+                    "Clang"
+            )
+        )
+    )
+        message(
+            WARNING
+            "Coverage was requested, but it is not supported for the ${CMAKE_CXX_COMPILER_ID} compiler."
+        )
     endif()
 endif()

--- a/gcovr.cfg
+++ b/gcovr.cfg
@@ -1,0 +1,11 @@
+# Configuration for gcovr, loaded automatically when --root points at this
+# directory. See the coverage section of the README.
+
+# Report on the library itself. The tests are the thing doing the measuring,
+# so their own coverage says nothing about covfie.
+filter = lib/
+
+# Every call that may throw adds a hidden branch for the unwind path. The
+# compiler generates these rather than the author writing them, and they made
+# up about two in five of all branches, so they drown out the real logic.
+exclude-throw-branches = yes


### PR DESCRIPTION
This commit adds a code coverage build option and a corresponding CI job which uses it. It runs the CPU-compatible test binaries and then reports the coverage report as an artifact.