### PR TITLE
Fix missing file pointer in constant IO

### DIFF
--- a/lib/core/covfie/core/backend/primitive/constant.hpp
+++ b/lib/core/covfie/core/backend/primitive/constant.hpp
@@ -66,7 +66,7 @@ struct constant {
             utility::read_io_header(fs, IO_MAGIC_HEADER);
 
             auto vec =
-                utility::read_binary<typename covariant_output_t::vector_t>();
+                utility::read_binary<typename covariant_output_t::vector_t>(fs);
 
             utility::read_io_footer(fs, IO_MAGIC_HEADER);
 


### PR DESCRIPTION
The constant backend IO currently doesn't pass a file pointer, which is necessary. This commit fixes this issue, passing the pointer as required.