### PR TITLE
Fix missing standard library includes

### DIFF
--- a/benchmarks/common/covfie/benchmark/register.hpp
+++ b/benchmarks/common/covfie/benchmark/register.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <benchmark/benchmark.h>
 #include <boost/core/demangle.hpp>
 #include <boost/mp11.hpp>

--- a/benchmarks/common/covfie/benchmark/types.hpp
+++ b/benchmarks/common/covfie/benchmark/types.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include <benchmark/benchmark.h>
 
 namespace covfie::benchmark {

--- a/benchmarks/cpu/backends/constant.hpp
+++ b/benchmarks/cpu/backends/constant.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include <covfie/core/backend/primitive/constant.hpp>
 #include <covfie/core/field.hpp>
 #include <covfie/core/parameter_pack.hpp>

--- a/benchmarks/cpu/patterns/lorentz.hpp
+++ b/benchmarks/cpu/patterns/lorentz.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <random>
 

--- a/benchmarks/cpu/patterns/random.hpp
+++ b/benchmarks/cpu/patterns/random.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <random>
 
 #include <covfie/benchmark/pattern.hpp>

--- a/benchmarks/cpu/patterns/sequential.hpp
+++ b/benchmarks/cpu/patterns/sequential.hpp
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+
 #include <covfie/core/backend/primitive/constant.hpp>
 #include <covfie/core/field.hpp>
 #include <covfie/core/vector.hpp>

--- a/benchmarks/cuda/patterns/euler.hpp
+++ b/benchmarks/cuda/patterns/euler.hpp
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <random>
 

--- a/benchmarks/cuda/patterns/lorentz.hpp
+++ b/benchmarks/cuda/patterns/lorentz.hpp
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <random>
 

--- a/benchmarks/cuda/patterns/random.hpp
+++ b/benchmarks/cuda/patterns/random.hpp
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <random>
 

--- a/benchmarks/cuda/patterns/runge_kutta4.hpp
+++ b/benchmarks/cuda/patterns/runge_kutta4.hpp
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <random>
 

--- a/benchmarks/cuda/patterns/scan.hpp
+++ b/benchmarks/cuda/patterns/scan.hpp
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <random>
 

--- a/benchmarks/openmp/backends/constant.hpp
+++ b/benchmarks/openmp/backends/constant.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include <covfie/core/backend/primitive/constant.hpp>
 #include <covfie/core/field.hpp>
 #include <covfie/core/vector.hpp>

--- a/benchmarks/openmp/patterns/euler.hpp
+++ b/benchmarks/openmp/patterns/euler.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <random>
 
 #include <covfie/benchmark/pattern.hpp>

--- a/benchmarks/openmp/patterns/lorentz.hpp
+++ b/benchmarks/openmp/patterns/lorentz.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <random>
 
 #include <covfie/benchmark/lorentz.hpp>

--- a/benchmarks/openmp/patterns/runge_kutta4.hpp
+++ b/benchmarks/openmp/patterns/runge_kutta4.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <random>
 
 #include <covfie/benchmark/pattern.hpp>

--- a/examples/common/bitmap/bitmap.cpp
+++ b/examples/common/bitmap/bitmap.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <cmath>
+#include <cstddef>
 #include <fstream>
 #include <string>
 

--- a/examples/core/convert_bfield.cpp
+++ b/examples/core/convert_bfield.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <cstddef>
 #include <fstream>
 #include <iostream>
 

--- a/examples/core/convert_bfield_csv.cpp
+++ b/examples/core/convert_bfield_csv.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <cstddef>
 #include <fstream>
 #include <iostream>
 #include <sstream>

--- a/examples/core/generate_test_field.cpp
+++ b/examples/core/generate_test_field.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <cstddef>
 #include <fstream>
 #include <iostream>
 

--- a/examples/core/readme_example_1.cpp
+++ b/examples/core/readme_example_1.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <cmath>
+#include <cstddef>
 #include <iostream>
 
 #include <covfie/core/backend/primitive/array.hpp>

--- a/examples/core/readme_example_2.cpp
+++ b/examples/core/readme_example_2.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <cmath>
+#include <cstddef>
 #include <iostream>
 
 #include <covfie/core/backend/primitive/array.hpp>

--- a/examples/core/scaleup_bfield.cpp
+++ b/examples/core/scaleup_bfield.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <cstddef>
 #include <fstream>
 #include <iostream>
 

--- a/examples/core/shuffle_asm.cpp
+++ b/examples/core/shuffle_asm.cpp
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <cstddef>
+
 #include <covfie/core/backend/primitive/array.hpp>
 #include <covfie/core/backend/transformer/dereference.hpp>
 #include <covfie/core/backend/transformer/shuffle.hpp>

--- a/lib/core/covfie/core/backend/primitive/array.hpp
+++ b/lib/core/covfie/core/backend/primitive/array.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <memory>

--- a/lib/core/covfie/core/backend/primitive/constant.hpp
+++ b/lib/core/covfie/core/backend/primitive/constant.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 
 #include <covfie/core/concepts.hpp>

--- a/lib/core/covfie/core/backend/primitive/identity.hpp
+++ b/lib/core/covfie/core/backend/primitive/identity.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <type_traits>
 #include <variant>

--- a/lib/core/covfie/core/backend/transformer/affine.hpp
+++ b/lib/core/covfie/core/backend/transformer/affine.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 
 #include <covfie/core/algebra/affine.hpp>

--- a/lib/core/covfie/core/backend/transformer/backup.hpp
+++ b/lib/core/covfie/core/backend/transformer/backup.hpp
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <type_traits>
 #include <variant>

--- a/lib/core/covfie/core/backend/transformer/clamp.hpp
+++ b/lib/core/covfie/core/backend/transformer/clamp.hpp
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <concepts>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <type_traits>
 #include <variant>

--- a/lib/core/covfie/core/backend/transformer/covariant_cast.hpp
+++ b/lib/core/covfie/core/backend/transformer/covariant_cast.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <variant>
 

--- a/lib/core/covfie/core/backend/transformer/covariant_select.hpp
+++ b/lib/core/covfie/core/backend/transformer/covariant_select.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <variant>
 

--- a/lib/core/covfie/core/backend/transformer/dereference.hpp
+++ b/lib/core/covfie/core/backend/transformer/dereference.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <variant>
 

--- a/lib/core/covfie/core/backend/transformer/hilbert.hpp
+++ b/lib/core/covfie/core/backend/transformer/hilbert.hpp
@@ -8,6 +8,8 @@
 
 #include <algorithm>
 #include <climits>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <numeric>

--- a/lib/core/covfie/core/backend/transformer/linear.hpp
+++ b/lib/core/covfie/core/backend/transformer/linear.hpp
@@ -8,6 +8,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <type_traits>
 #include <utility>

--- a/lib/core/covfie/core/backend/transformer/morton.hpp
+++ b/lib/core/covfie/core/backend/transformer/morton.hpp
@@ -8,6 +8,8 @@
 
 #include <algorithm>
 #include <climits>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <numeric>

--- a/lib/core/covfie/core/backend/transformer/nearest_neighbour.hpp
+++ b/lib/core/covfie/core/backend/transformer/nearest_neighbour.hpp
@@ -8,6 +8,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <type_traits>
 #include <variant>

--- a/lib/core/covfie/core/backend/transformer/shuffle.hpp
+++ b/lib/core/covfie/core/backend/transformer/shuffle.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <variant>
 

--- a/lib/core/covfie/core/backend/transformer/strided.hpp
+++ b/lib/core/covfie/core/backend/transformer/strided.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <numeric>

--- a/lib/core/covfie/core/field.hpp
+++ b/lib/core/covfie/core/field.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 
 #include <covfie/core/concepts.hpp>

--- a/lib/core/covfie/core/utility/nd_map.hpp
+++ b/lib/core/covfie/core/utility/nd_map.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <functional>
 #include <utility>
 

--- a/lib/core/covfie/core/utility/nd_size.hpp
+++ b/lib/core/covfie/core/utility/nd_size.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include <covfie/core/array.hpp>
 
 namespace covfie::utility {

--- a/lib/cpu/covfie/cpu/backend/primitive/c_array.hpp
+++ b/lib/cpu/covfie/cpu/backend/primitive/c_array.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 
 #include <covfie/core/backend/primitive/array.hpp>

--- a/lib/cuda/covfie/cuda/backend/primitive/cuda_device_array.hpp
+++ b/lib/cuda/covfie/cuda/backend/primitive/cuda_device_array.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 
 #include <cuda_runtime.h>

--- a/lib/cuda/covfie/cuda/backend/primitive/cuda_texture.hpp
+++ b/lib/cuda/covfie/cuda/backend/primitive/cuda_texture.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 

--- a/lib/cuda/covfie/cuda/utility/memory.hpp
+++ b/lib/cuda/covfie/cuda/utility/memory.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <optional>
 

--- a/lib/hip/covfie/hip/backend/primitive/hip_device_array.hpp
+++ b/lib/hip/covfie/hip/backend/primitive/hip_device_array.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 
 #include <hip/hip_runtime.h>

--- a/lib/hip/covfie/hip/utility/memory.hpp
+++ b/lib/hip/covfie/hip/utility/memory.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <optional>
 

--- a/lib/sycl/covfie/sycl/backend/primitive/sycl_device_array.hpp
+++ b/lib/sycl/covfie/sycl/backend/primitive/sycl_device_array.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 
 #include <covfie/core/backend/primitive/array.hpp>

--- a/lib/sycl/covfie/sycl/utility/memory.hpp
+++ b/lib/sycl/covfie/sycl/utility/memory.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 
 #include <sycl/sycl.hpp>

--- a/tests/core/test_array_binary_io.cpp
+++ b/tests/core/test_array_binary_io.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <cstddef>
 #include <fstream>
 
 #include <boost/filesystem.hpp>

--- a/tests/core/test_binary_io.cpp
+++ b/tests/core/test_binary_io.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <fstream>

--- a/tests/core/test_utility.cpp
+++ b/tests/core/test_utility.cpp
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <cstddef>
+
 #include <gtest/gtest.h>
 
 #include <covfie/core/utility/nd_map.hpp>

--- a/tests/cuda/test_cuda_array.cu
+++ b/tests/cuda/test_cuda_array.cu
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <cstddef>
 #include <optional>
 #include <utility>
 

--- a/tests/cuda/test_cuda_strided_array.cu
+++ b/tests/cuda/test_cuda_strided_array.cu
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <cstddef>
 #include <optional>
 #include <utility>
 

--- a/tests/cuda/test_cuda_texture.cu
+++ b/tests/cuda/test_cuda_texture.cu
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <cstddef>
 #include <optional>
 #include <utility>
 

--- a/tests/hip/test_hip_array.hip
+++ b/tests/hip/test_hip_array.hip
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <cstddef>
 #include <optional>
 #include <utility>
 

--- a/tests/sycl/test_sycl_array.cpp
+++ b/tests/sycl/test_sycl_array.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <cstddef>
 #include <optional>
 #include <utility>
 


### PR DESCRIPTION
This commit adds some missing includes of cstddef and cstdint in order to fix some compiler errors.